### PR TITLE
Don't warn about pure-python murmur on PyPy.

### DIFF
--- a/afkak/partitioner.py
+++ b/afkak/partitioner.py
@@ -24,7 +24,12 @@ try:
     murmur2_hash = murmur2_hash_c
 
 except ImportError:  # pragma: no cover
-    warnings.warn("Import of murmur failed, using pure python", ImportWarning)
+    try:
+        import __pypy__
+    except ImportError:
+        warnings.warn(
+            "Import of murmur failed, using pure python", ImportWarning,
+        )
     murmur2_hash = None
 
 


### PR DESCRIPTION
On PyPy, it's preferred.