### PR TITLE
fix consumer example

### DIFF
--- a/consumer_example
+++ b/consumer_example
@@ -83,7 +83,7 @@ class ConsumerExample(object):
             return result
         dl.addBoth(_stop_reactor)
 
-    def msg_processor(self, msglist):
+    def msg_processor(self, consumer, msglist):
         for msg in msglist:
             log.info("proc: msg: %r", msg)
 


### PR DESCRIPTION
consumer_example didn't work out of the box. Looking at the codes it seems that there is an arguments passed before msglist. 