### PR TITLE
Bump minimum twisted version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name="afkak",
     version="2.3.0",
 
-    install_requires=['Twisted>=13.2.0'],
+    install_requires=['Twisted>=16.5.0'],
     extras_require={
         'FastMurmur2': ['Murmur>=0.1.3'],
     },


### PR DESCRIPTION
Commit 8b2033b (Updated _collect_hosts() for IP resolution - 2016-06-08) starts to use twisted.names.client, which is only available since 16.5.0