### PR TITLE
fix "list index out of range" error when there are no more messages left to be processed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@ Version 3.0.0.dev0
 ------------------
 
 * Add ``snappy`` setuptools extra which pulls in python-snappy (required for Snappy compression support).
+* Fix BPSO-94789: In rare cases when consumer was stopped exactly
+  at the moment when all the messages got processed but _process_message 
+  was still scheduled afkak will produce a traceback with 
+  "list index out of range" exception
 
 Version 2.9.0
 -------------

--- a/afkak/consumer.py
+++ b/afkak/consumer.py
@@ -846,7 +846,7 @@ class Consumer(object):
             if self._msg_block_d:
                 _msg_block_d, self._msg_block_d = self._msg_block_d, None
                 _msg_block_d.callback(True)
-                return
+            return
         # Yes, we've got some messages to process.
         # Default to processing the entire block...
         proc_block_size = sys.maxsize

--- a/afkak/test/test_consumer.py
+++ b/afkak/test/test_consumer.py
@@ -1681,3 +1681,28 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         # Stop the consumer to cleanup any outstanding operations
         consumer.stop()
         self.assertEqual(self.successResultOf(d), (None, None))
+
+    def test_consumer_process_messages_should_exit_when_no_messages_left(self):
+        client = Mock()
+        a_partition = 9
+        a_processor = Mock()
+        a_consumer_group = 'My Consumer Group'
+
+        consumer = Consumer(
+            client, 'a_topic', a_partition, a_processor, a_consumer_group,
+        )
+
+        self.assertIsNone(consumer._process_messages([]))
+
+    def test_consumer_process_messages_should_notify_msg_block_when_no_messages_left(self):
+        client = Mock()
+        a_partition = 9
+        a_processor = Mock()
+        a_consumer_group = 'My Consumer Group'
+
+        consumer = Consumer(
+            client, 'a_topic', a_partition, a_processor, a_consumer_group,
+        )
+        d = consumer._msg_block_d = Deferred()
+        consumer._process_messages([])
+        self.assertTrue(self.successResultOf(d))


### PR DESCRIPTION
Fixing the following scenario:

Given there are no messages left to be processed 
And the next Consumer._process_messages call was scheduled
Given Consumer.stop method was called 
When Consumer._process_messages call executed then _msg_block_d will be None and Consumer._process_messages will crash with "list index out of range" exception. 