### PR TITLE
More error code work

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,7 +52,9 @@ Version 3.0.0.dev0
   "list index out of range" exception
 
 * Exception types for additional broker error codes have been added.
-  These exceptions derive from `afkak.common.BrokerResponseError`, which has also grown a `retriable` attribute.
+  These exceptions derive from `afkak.common.BrokerResponseError`.
+  A subclass, `afkak.common.RetriableBrokerResponseError`, marks those error codes which are retriable.
+  This information is also available as a bool on the `retriable` attribute.
 
   * The `message` attribute of these types has changed to match the upstream table:
 

--- a/afkak/common.py
+++ b/afkak/common.py
@@ -151,6 +151,14 @@ class BrokerResponseError(KafkaError):
     message = None
 
 
+class RetriableBrokerResponseError(BrokerResponseError):
+    """
+    `RetriableBrokerResponseError` is the shared superclass of all broker
+    errors which can be retried.
+    """
+    retriable = True
+
+
 class UnknownError(BrokerResponseError):
     errno = -1
     message = 'UNKNOWN_SERVER_ERROR'
@@ -161,18 +169,16 @@ class OffsetOutOfRangeError(BrokerResponseError):
     message = 'OFFSET_OUT_OF_RANGE'
 
 
-class CorruptMessage(BrokerResponseError):
+class CorruptMessage(RetriableBrokerResponseError):
     errno = 2
-    retriable = True
     message = 'CORRUPT_MESSAGE'
 
 # Compatibility alias:
 InvalidMessageError = CorruptMessage
 
 
-class UnknownTopicOrPartitionError(BrokerResponseError):
+class UnknownTopicOrPartitionError(RetriableBrokerResponseError):
     errno = 3
-    retriable = True
     message = 'UNKNOWN_TOPIC_OR_PARTITION'
 
 
@@ -181,21 +187,18 @@ class InvalidFetchRequestError(BrokerResponseError):
     message = 'INVALID_FETCH_SIZE'
 
 
-class LeaderNotAvailableError(BrokerResponseError):
+class LeaderNotAvailableError(RetriableBrokerResponseError):
     errno = 5
-    retriable = True
     message = 'LEADER_NOT_AVAILABLE'
 
 
-class NotLeaderForPartitionError(BrokerResponseError):
+class NotLeaderForPartitionError(RetriableBrokerResponseError):
     errno = 6
-    retriable = True
     message = 'NOT_LEADER_FOR_PARTITION'
 
 
-class RequestTimedOutError(BrokerResponseError):
+class RequestTimedOutError(RetriableBrokerResponseError):
     errno = 7
-    retriable = True
     message = 'REQUEST_TIMED_OUT'
 
 
@@ -224,33 +227,29 @@ class OffsetMetadataTooLargeError(BrokerResponseError):
     message = 'OFFSET_METADATA_TOO_LARGE'
 
 
-class NetworkException(BrokerResponseError):
+class NetworkException(RetriableBrokerResponseError):
     errno = 13
-    retriable = True
     message = 'NETWORK_EXCEPTION'
 
 StaleLeaderEpochCodeError = NetworkException
 
 
-class CoordinatorLoadInProgress(BrokerResponseError):
+class CoordinatorLoadInProgress(RetriableBrokerResponseError):
     errno = 14
-    retriable = True
     message = 'COORDINATOR_LOAD_IN_PROGRESS'
 
 OffsetsLoadInProgressError = CoordinatorLoadInProgress
 
 
-class CoordinatorNotAvailable(BrokerResponseError):
+class CoordinatorNotAvailable(RetriableBrokerResponseError):
     errno = 15
-    retriable = True
     message = 'COORDINATOR_NOT_AVAILABLE'
 
 ConsumerCoordinatorNotAvailableError = CoordinatorNotAvailable
 
 
-class NotCoordinator(BrokerResponseError):
+class NotCoordinator(RetriableBrokerResponseError):
     errno = 16
-    retriable = True
     message = 'NOT_COORDINATOR'
 
 NotCoordinatorForConsumerError = NotCoordinator
@@ -274,23 +273,21 @@ class RecordListTooLarge(BrokerResponseError):
     message = "RECORD_LIST_TOO_LARGE"
 
 
-class NotEnoughReplicas(BrokerResponseError):
+class NotEnoughReplicas(RetriableBrokerResponseError):
     """
     The number of in-sync replicas is lower than can satisfy the number of acks
     required by the produce request.
     """
     errno = 19
-    retriable = True
     message = "NOT_ENOUGH_REPLICAS"
 
 
-class NotEnoughReplicasAfterAppend(BrokerResponseError):
+class NotEnoughReplicasAfterAppend(RetriableBrokerResponseError):
     """
     The produce request was written to the log, but not by as many in-sync
     replicas as it required.
     """
     errno = 20
-    retriable = True
     message = "NOT_ENOUGH_REPLICAS_AFTER_APPEND"
 
 

--- a/afkak/common.py
+++ b/afkak/common.py
@@ -143,7 +143,8 @@ class BrokerResponseError(KafkaError):
     :ivar str message:
         The error code string, per the table. ``None`` if the error code is
         unknown to Afkak (future Kafka releases may add additional error
-        codes).
+        codes). Note that this value may change for a given exception type.
+        Code should either check the exception type or errno.
 
     .. _error code: https://kafka.apache.org/protocol.html#protocol_error_codes
     """
@@ -346,6 +347,211 @@ class ClusterAuthorizationFailed(BrokerResponseError):
     message = "CLUSTER_AUTHORIZATION_FAILED"
 
 
+class InvalidTimestamp(BrokerResponseError):
+    errno = 32
+    message = 'INVALID_TIMESTAMP'
+
+
+class UnsupportedSaslMechanism(BrokerResponseError):
+    errno = 33
+    message = 'UNSUPPORTED_SASL_MECHANISM'
+
+
+class IllegalSaslState(BrokerResponseError):
+    errno = 34
+    message = 'ILLEGAL_SASL_STATE'
+
+
+class UnsupportedVersion(BrokerResponseError):
+    errno = 35
+    message = 'UNSUPPORTED_VERSION'
+
+
+class TopicAlreadyExists(BrokerResponseError):
+    errno = 36
+    message = 'TOPIC_ALREADY_EXISTS'
+
+
+class InvalidPartitions(BrokerResponseError):
+    errno = 37
+    message = 'INVALID_PARTITIONS'
+
+
+class InvalidReplicationFactor(BrokerResponseError):
+    errno = 38
+    message = 'INVALID_REPLICATION_FACTOR'
+
+
+class InvalidReplicaAssignment(BrokerResponseError):
+    errno = 39
+    message = 'INVALID_REPLICA_ASSIGNMENT'
+
+
+class InvalidConfig(BrokerResponseError):
+    errno = 40
+    message = 'INVALID_CONFIG'
+
+
+class NotController(RetriableBrokerResponseError):
+    errno = 41
+    message = 'NOT_CONTROLLER'
+
+
+class InvalidRequest(BrokerResponseError):
+    errno = 42
+    message = 'INVALID_REQUEST'
+
+
+class UnsupportedForMessageFormat(BrokerResponseError):
+    errno = 43
+    message = 'UNSUPPORTED_FOR_MESSAGE_FORMAT'
+
+
+class PolicyViolation(BrokerResponseError):
+    errno = 44
+    message = 'POLICY_VIOLATION'
+
+
+class OutOfOrderSequenceNumber(BrokerResponseError):
+    errno = 45
+    message = 'OUT_OF_ORDER_SEQUENCE_NUMBER'
+
+
+class DuplicateSequenceNumber(BrokerResponseError):
+    errno = 46
+    message = 'DUPLICATE_SEQUENCE_NUMBER'
+
+
+class InvalidProducerEpoch(BrokerResponseError):
+    errno = 47
+    message = 'INVALID_PRODUCER_EPOCH'
+
+
+class InvalidTxnState(BrokerResponseError):
+    errno = 48
+    message = 'INVALID_TXN_STATE'
+
+
+class InvalidProducerIdMapping(BrokerResponseError):
+    errno = 49
+    message = 'INVALID_PRODUCER_ID_MAPPING'
+
+
+class InvalidTransactionTimeout(BrokerResponseError):
+    errno = 50
+    message = 'INVALID_TRANSACTION_TIMEOUT'
+
+
+class ConcurrentTransactions(BrokerResponseError):
+    errno = 51
+    message = 'CONCURRENT_TRANSACTIONS'
+
+
+class TransactionCoordinatorFenced(BrokerResponseError):
+    errno = 52
+    message = 'TRANSACTION_COORDINATOR_FENCED'
+
+
+class TransactionalIdAuthorizationFailed(BrokerResponseError):
+    errno = 53
+    message = 'TRANSACTIONAL_ID_AUTHORIZATION_FAILED'
+
+
+class SecurityDisabled(BrokerResponseError):
+    errno = 54
+    message = 'SECURITY_DISABLED'
+
+
+class OperationNotAttempted(BrokerResponseError):
+    errno = 55
+    message = 'OPERATION_NOT_ATTEMPTED'
+
+
+class KafkaStorageError(RetriableBrokerResponseError):
+    errno = 56
+    message = 'KAFKA_STORAGE_ERROR'
+
+
+class LogDirNotFound(BrokerResponseError):
+    errno = 57
+    message = 'LOG_DIR_NOT_FOUND'
+
+
+class SaslAuthenticationFailed(BrokerResponseError):
+    errno = 58
+    message = 'SASL_AUTHENTICATION_FAILED'
+
+
+class UnknownProducerId(BrokerResponseError):
+    errno = 59
+    message = 'UNKNOWN_PRODUCER_ID'
+
+
+class ReassignmentInProgress(BrokerResponseError):
+    errno = 60
+    message = 'REASSIGNMENT_IN_PROGRESS'
+
+
+class DelegationTokenAuthDisabled(BrokerResponseError):
+    errno = 61
+    message = 'DELEGATION_TOKEN_AUTH_DISABLED'
+
+
+class DelegationTokenNotFound(BrokerResponseError):
+    errno = 62
+    message = 'DELEGATION_TOKEN_NOT_FOUND'
+
+
+class DelegationTokenOwnerMismatch(BrokerResponseError):
+    errno = 63
+    message = 'DELEGATION_TOKEN_OWNER_MISMATCH'
+
+
+class DelegationTokenRequestNotAllowed(BrokerResponseError):
+    errno = 64
+    message = 'DELEGATION_TOKEN_REQUEST_NOT_ALLOWED'
+
+
+class DelegationTokenAuthorizationFailed(BrokerResponseError):
+    errno = 65
+    message = 'DELEGATION_TOKEN_AUTHORIZATION_FAILED'
+
+
+class DelegationTokenExpired(BrokerResponseError):
+    errno = 66
+    message = 'DELEGATION_TOKEN_EXPIRED'
+
+
+class InvalidPrincipalType(BrokerResponseError):
+    errno = 67
+    message = 'INVALID_PRINCIPAL_TYPE'
+
+
+class NonEmptyGroup(BrokerResponseError):
+    errno = 68
+    message = 'NON_EMPTY_GROUP'
+
+
+class GroupIdNotFound(BrokerResponseError):
+    errno = 69
+    message = 'GROUP_ID_NOT_FOUND'
+
+
+class FetchSessionIdNotFound(RetriableBrokerResponseError):
+    errno = 70
+    message = 'FETCH_SESSION_ID_NOT_FOUND'
+
+
+class InvalidFetchSessionEpoch(RetriableBrokerResponseError):
+    errno = 71
+    message = 'INVALID_FETCH_SESSION_EPOCH'
+
+
+class ListenerNotFound(RetriableBrokerResponseError):
+    errno = 72
+    message = 'LISTENER_NOT_FOUND'
+
+
 class KafkaUnavailableError(KafkaError):
     pass
 
@@ -444,6 +650,47 @@ BrokerResponseError.errnos = {
     29: TopicAuthorizationFailed,
     30: GroupAuthorizationFailed,
     31: ClusterAuthorizationFailed,
+    32: InvalidTimestamp,
+    33: UnsupportedSaslMechanism,
+    34: IllegalSaslState,
+    35: UnsupportedVersion,
+    36: TopicAlreadyExists,
+    37: InvalidPartitions,
+    38: InvalidReplicationFactor,
+    39: InvalidReplicaAssignment,
+    40: InvalidConfig,
+    41: NotController,
+    42: InvalidRequest,
+    43: UnsupportedForMessageFormat,
+    44: PolicyViolation,
+    45: OutOfOrderSequenceNumber,
+    46: DuplicateSequenceNumber,
+    47: InvalidProducerEpoch,
+    48: InvalidTxnState,
+    49: InvalidProducerIdMapping,
+    50: InvalidTransactionTimeout,
+    51: ConcurrentTransactions,
+    52: TransactionCoordinatorFenced,
+    53: TransactionalIdAuthorizationFailed,
+    54: SecurityDisabled,
+    55: OperationNotAttempted,
+    56: KafkaStorageError,
+    57: LogDirNotFound,
+    58: SaslAuthenticationFailed,
+    59: UnknownProducerId,
+    60: ReassignmentInProgress,
+    61: DelegationTokenAuthDisabled,
+    62: DelegationTokenNotFound,
+    63: DelegationTokenOwnerMismatch,
+    64: DelegationTokenRequestNotAllowed,
+    65: DelegationTokenAuthorizationFailed,
+    66: DelegationTokenExpired,
+    67: InvalidPrincipalType,
+    68: NonEmptyGroup,
+    69: GroupIdNotFound,
+    70: FetchSessionIdNotFound,
+    71: InvalidFetchSessionEpoch,
+    72: ListenerNotFound,
 }
 
 

--- a/afkak/test/test_common.py
+++ b/afkak/test/test_common.py
@@ -18,27 +18,29 @@
 Test the afkak.common module.
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 
 from afkak import common
-from afkak.common import (
-    BrokerResponseError,
-    ProduceResponse, FetchResponse, OffsetResponse, OffsetCommitResponse,
-    OffsetFetchResponse, LeaderNotAvailableError, _check_error,
-    UnknownTopicOrPartitionError, MessageSizeTooLargeError,
-    OffsetOutOfRangeError, OffsetMetadataTooLargeError,
-    NotCoordinator, CoordinatorLoadInProgress,
-    CoordinatorNotAvailable, ConsumerMetadataResponse,
-)
+from afkak.common import (BrokerResponseError, ConsumerMetadataResponse,
+                          CoordinatorLoadInProgress, CoordinatorNotAvailable,
+                          FetchResponse, LeaderNotAvailableError,
+                          MessageSizeTooLargeError, NotCoordinator,
+                          OffsetCommitResponse, OffsetFetchResponse,
+                          OffsetMetadataTooLargeError, OffsetOutOfRangeError,
+                          OffsetResponse, ProduceResponse,
+                          RetriableBrokerResponseError,
+                          UnknownTopicOrPartitionError, _check_error)
 
 
 class TestAfkakCommon(unittest.TestCase):
+    maxDiff = None
+
     def test_error_codes(self):
         """
-        The `afkak.common.kafka_errors` mapping includes all subclasses of
-        `BrokerError` by errno attribute.
+        The `afkak.common.BrokerResponseError.errnos` mapping includes all
+        concrete subclasses of `BrokerResponseError` by errno attribute.
         """
         count = 0
         expected = {}
@@ -47,6 +49,8 @@ class TestAfkakCommon(unittest.TestCase):
             if not isinstance(value, type):
                 continue
             if value is BrokerResponseError:
+                continue
+            if value is RetriableBrokerResponseError:
                 continue
             if value.__name__ != name:
                 continue  # Skip backwards-compatibility aliases.

--- a/afkak/test/test_failover_integration.py
+++ b/afkak/test/test_failover_integration.py
@@ -14,29 +14,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import logging
+import os
 import time
 
-from nose.twistedtools import threaded_reactor, deferred
+import afkak.client as kclient
+from afkak import KafkaClient, Producer
+from afkak.common import (PRODUCER_ACK_ALL_REPLICAS, FailedPayloadsError,
+                          FetchRequest, KafkaUnavailableError,
+                          NotLeaderForPartitionError, RequestTimedOutError,
+                          TopicAndPartition, UnknownTopicOrPartitionError,
+                          _check_error)
+from mock import patch
+from nose.twistedtools import deferred, threaded_reactor
 from twisted.internet.defer import inlineCallbacks, returnValue
 
-from mock import patch
-
-from afkak import (KafkaClient, Producer)
-import afkak.client as kclient
-
-from afkak.common import (
-    TopicAndPartition, _check_error, FetchRequest, NotLeaderForPartitionError,
-    RequestTimedOutError, UnknownTopicOrPartitionError, FailedPayloadsError,
-    KafkaUnavailableError,
-    )
-
-from .fixtures import ZookeeperFixture, KafkaFixture
-from .testutil import (
-    kafka_versions, KafkaIntegrationTestCase,
-    random_string, ensure_topic_creation, async_delay,
-    )
+from .fixtures import KafkaFixture, ZookeeperFixture
+from .testutil import (KafkaIntegrationTestCase, async_delay,
+                       ensure_topic_creation, kafka_versions, random_string)
 
 log = logging.getLogger(__name__)
 
@@ -102,7 +97,13 @@ class TestFailover(KafkaIntegrationTestCase):
     @deferred(timeout=600)
     @inlineCallbacks
     def test_switch_leader(self):
-        producer = Producer(self.client)
+        """
+        Produce messages while killing the coordinator broker.
+
+        Note that in order to avoid loss of acknowledged writes the producer
+        must request acks of -1 (`afkak.common.PRODUCER_ACK_ALL_REPLICAS`).
+        """
+        producer = Producer(self.client, req_acks=PRODUCER_ACK_ALL_REPLICAS)
         topic = self.topic
         try:
             for index in range(1, 3):
@@ -112,8 +113,7 @@ class TestFailover(KafkaIntegrationTestCase):
 
                 # Ensure that the follower is in sync
                 log.debug("Ensuring topic/partition is replicated.")
-                part_meta = self.client.partition_meta[TopicAndPartition(
-                    self.topic, 0)]
+                part_meta = self.client.partition_meta[TopicAndPartition(self.topic, 0)]
                 # Ensure the all the replicas are in-sync before proceeding
                 while len(part_meta.isr) != 2:  # pragma: no cover
                     log.debug("Waiting for Kafka replica to become synced")

--- a/afkak/test/test_failover_integration.py
+++ b/afkak/test/test_failover_integration.py
@@ -186,8 +186,7 @@ class TestFailover(KafkaIntegrationTestCase):
         client = KafkaClient(hosts, clientId="CountMessages", timeout=500)
 
         try:
-            yield ensure_topic_creation(client, topic, fully_replicated=False,
-                                        reactor=self.reactor)
+            yield ensure_topic_creation(client, topic, fully_replicated=False)
 
             # Need to retry this until we have a leader...
             while True:


### PR DESCRIPTION
* Split out a `RetriableBrokerResponseError` superclass so that `except` and `failure.trap()` can differentiate retriable errors by type.
* Add the rest of the error codes from https://kafka.apache.org/protocol.html#protocol_error_codes