### PR TITLE
Linting

### DIFF
--- a/afkak/brokerclient.py
+++ b/afkak/brokerclient.py
@@ -13,18 +13,13 @@ import logging
 from collections import OrderedDict
 from functools import partial
 
-from twisted.internet.error import (ConnectionDone, UserError)
+from twisted.internet.defer import Deferred, fail, succeed
+from twisted.internet.error import ConnectionDone, UserError
 from twisted.internet.protocol import ReconnectingClientFactory
-from twisted.internet.defer import (
-    Deferred, DeferredList, maybeDeferred, fail, succeed,
-)
 
-from .protocol import KafkaProtocol
+from .common import CancelledError, ClientError, DuplicateRequestError
 from .kafkacodec import KafkaCodec
-from .common import (
-    ClientError, DuplicateRequestError, DefaultKafkaPort,
-    CancelledError,
-)
+from .protocol import KafkaProtocol
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())

--- a/afkak/client.py
+++ b/afkak/client.py
@@ -244,7 +244,8 @@ class KafkaClient(object):
             return False
         return all(
             self.partition_fully_replicated(TopicAndPartition(topic, p))
-                 for p in self.topic_partitions[topic])
+            for p in self.topic_partitions[topic]
+        )
 
     def close(self):
         # If we're already waiting on an/some outstanding disconnects

--- a/afkak/common.py
+++ b/afkak/common.py
@@ -166,6 +166,7 @@ class CorruptMessage(BrokerResponseError):
     retriable = True
     message = 'CORRUPT_MESSAGE'
 
+
 # Compatibility alias:
 InvalidMessageError = CorruptMessage
 
@@ -229,6 +230,8 @@ class NetworkException(BrokerResponseError):
     retriable = True
     message = 'NETWORK_EXCEPTION'
 
+
+# Compatibility alias:
 StaleLeaderEpochCodeError = NetworkException
 
 
@@ -237,6 +240,8 @@ class CoordinatorLoadInProgress(BrokerResponseError):
     retriable = True
     message = 'COORDINATOR_LOAD_IN_PROGRESS'
 
+
+# Compatibility alias:
 OffsetsLoadInProgressError = CoordinatorLoadInProgress
 
 
@@ -245,6 +250,8 @@ class CoordinatorNotAvailable(BrokerResponseError):
     retriable = True
     message = 'COORDINATOR_NOT_AVAILABLE'
 
+
+# Compatibility alias:
 ConsumerCoordinatorNotAvailableError = CoordinatorNotAvailable
 
 
@@ -253,6 +260,8 @@ class NotCoordinator(BrokerResponseError):
     retriable = True
     message = 'NOT_COORDINATOR'
 
+
+# Compatibility alias:
 NotCoordinatorForConsumerError = NotCoordinator
 
 

--- a/afkak/kafkacodec.py
+++ b/afkak/kafkacodec.py
@@ -8,24 +8,19 @@ import logging
 import struct
 import zlib
 
-import six
 from twisted.python.compat import nativeString
 
-from .codec import (
-    gzip_encode, gzip_decode, snappy_encode, snappy_decode
-)
-from .common import (
-    BrokerMetadata, PartitionMetadata, Message, OffsetAndMessage,
-    ProduceResponse, FetchResponse, OffsetResponse, TopicMetadata,
-    OffsetCommitResponse, OffsetFetchResponse, ProtocolError,
-    BufferUnderflowError, ChecksumError, ConsumerFetchSizeTooSmall,
-    UnsupportedCodecError, InvalidMessageError, ConsumerMetadataResponse,
-)
-from .util import (
-    read_short_ascii, read_short_bytes, read_int_string, relative_unpack,
-    write_short_ascii, write_short_bytes, write_int_string,
-    group_by_topic_and_partition,
-)
+from .codec import gzip_decode, gzip_encode, snappy_decode, snappy_encode
+from .common import (BrokerMetadata, BufferUnderflowError, ChecksumError,
+                     ConsumerFetchSizeTooSmall, ConsumerMetadataResponse,
+                     FetchResponse, InvalidMessageError, Message,
+                     OffsetAndMessage, OffsetCommitResponse,
+                     OffsetFetchResponse, OffsetResponse, PartitionMetadata,
+                     ProduceResponse, ProtocolError, TopicMetadata,
+                     UnsupportedCodecError)
+from .util import (group_by_topic_and_partition, read_int_string,
+                   read_short_ascii, read_short_bytes, relative_unpack,
+                   write_int_string, write_short_ascii, write_short_bytes)
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())

--- a/afkak/partitioner.py
+++ b/afkak/partitioner.py
@@ -106,6 +106,7 @@ def pure_murmur2(byte_array, seed=0x9747b28c):
 
     return h
 
+
 if murmur2_hash is None:  # pragma: no cover
     murmur2_hash = pure_murmur2
 

--- a/afkak/test/__init__.py
+++ b/afkak/test/__init__.py
@@ -19,7 +19,7 @@ import logging
 
 def _twisted_debug():
     """
-    When the ``AFKAK_TWISTED_DEBUGGING`` environment variable is set, enable
+    When the ``AFKAK_TWISTED_DEBUG`` environment variable is set, enable
     debugging of deferreds and delayed calls.
     """
     if os.environ.get('AFKAK_TWISTED_DEBUG'):
@@ -39,7 +39,8 @@ def _nose_log_to_file():
         return
 
     handler = logging.FileHandler(path)
-    handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)8s %(threadName)8s %(name)10s %(filename)s:%(lineno)d: %(message)s'))
+    handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)8s %(threadName)8s'
+                                           ' %(name)10s %(filename)s:%(lineno)d: %(message)s'))
 
     root = logging.getLogger()
     root.setLevel(logging.DEBUG)

--- a/afkak/test/fixtures.py
+++ b/afkak/test/fixtures.py
@@ -12,15 +12,10 @@ import subprocess
 import tempfile
 import uuid
 
-from six.moves.urllib.request import urlopen
-from six.moves.urllib.error import HTTPError
 from six.moves.urllib.parse import urlparse
 
 from .service import ExternalService, SpawnedService
 from .testutil import get_open_port
-
-log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
 
 
 class Fixture(object):

--- a/afkak/test/service.py
+++ b/afkak/test/service.py
@@ -1,16 +1,13 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2015 Cyan, Inc.
 
-from datetime import datetime, timedelta
 import logging
-from pprint import pformat
-import re
+import os
 import select
 import subprocess
 import threading
-import time
-import errno
-import os
+from datetime import datetime, timedelta
+from pprint import pformat
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -104,9 +101,9 @@ class SpawnedService(object):
                     proc.kill()
                     killed = True
 
-
     def start(self, timeout=10):
         assert self._thread is None
+
         def run():
             try:
                 self._run()

--- a/afkak/test/test_brokerclient.py
+++ b/afkak/test/test_brokerclient.py
@@ -14,13 +14,11 @@ import logging
 from mock import Mock, patch
 
 from twisted.internet.address import IPv4Address
-from twisted.internet.base import DelayedCall
-from twisted.internet.defer import Deferred, setDebugging
+from twisted.internet.defer import Deferred
 from twisted.internet.error import (
     ConnectionRefusedError, ConnectionDone, UserError, NotConnectingError)
 from twisted.internet.protocol import Protocol
 from twisted.protocols.basic import StringTooLongError
-from twisted.internet.task import Clock
 from twisted.python.failure import Failure
 from twisted.test import proto_helpers
 from twisted.test.proto_helpers import MemoryReactorClock, _FakeConnector
@@ -429,7 +427,7 @@ class KafkaBrokerClientTestCase(unittest.TestCase):
     def test_makeRequest_fails(self):
         id1 = 15432
         reactor = MemoryReactorClock()
-        c = KafkaBrokerClient(reactor,'testmakeRequest', 9092, 'clientId')
+        c = KafkaBrokerClient(reactor, 'testmakeRequest', 9092, 'clientId')
         request = KafkaCodec.encode_fetch_request(b'testmakeRequest', id1)
         d = c.makeRequest(id1, request)
         eb1 = Mock()

--- a/afkak/test/test_client.py
+++ b/afkak/test/test_client.py
@@ -3,45 +3,42 @@
 # Copyright 2017, 2018 Ciena Corporation
 
 """
-Test code for KafkaClient(object) class.
+Test code for KafkaClient class.
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
-from functools import partial
+import logging
+import struct
 from copy import copy
-from twisted.trial import unittest
-from twisted.internet.defer import Deferred, succeed, fail
-from twisted.internet.error import (
-    ConnectionDone, ConnectionLost, UserError,
-)
-from twisted.test.proto_helpers import MemoryReactorClock
-from twisted.names.dns import RRHeader, Record_A, Record_CNAME
+from functools import partial
+
+from mock import ANY, MagicMock, Mock, call, patch
+from twisted.internet.defer import Deferred, fail, succeed
+from twisted.internet.error import ConnectionDone, ConnectionLost, UserError
+from twisted.names.dns import Record_A, Record_CNAME, RRHeader
 from twisted.names.error import DomainError
 from twisted.python.compat import nativeString
 from twisted.python.failure import Failure
+from twisted.test.proto_helpers import MemoryReactorClock
+from twisted.trial import unittest
 
-import struct
-import logging
-
-from mock import MagicMock, Mock, patch, ANY, call
-
-from afkak import KafkaClient
-from afkak.brokerclient import _KafkaBrokerClient
-from afkak.common import (
-    ProduceRequest, ProduceResponse, FetchRequest, FetchResponse,
-    OffsetRequest, OffsetResponse, OffsetCommitRequest, OffsetCommitResponse,
-    OffsetFetchRequest, OffsetFetchResponse,
-    BrokerMetadata, PartitionMetadata, TopicMetadata,
-    RequestTimedOutError, TopicAndPartition, KafkaUnavailableError,
-    DefaultKafkaPort, LeaderUnavailableError, PartitionUnavailableError,
-    FailedPayloadsError, NotLeaderForPartitionError, OffsetAndMessage,
-    UnknownTopicOrPartitionError, ConsumerCoordinatorNotAvailableError,
-    NotCoordinatorForConsumerError,
-)
-from afkak.kafkacodec import create_message, KafkaCodec
-from afkak.client import _collect_hosts
-import afkak.client as kclient  # for patching
+from .. import KafkaClient
+from .. import client as kclient  # for patching
+from ..brokerclient import _KafkaBrokerClient
+from ..client import _collect_hosts
+from ..common import (BrokerMetadata, ConsumerCoordinatorNotAvailableError,
+                      DefaultKafkaPort, FailedPayloadsError, FetchRequest,
+                      FetchResponse, KafkaUnavailableError,
+                      LeaderUnavailableError, NotCoordinatorForConsumerError,
+                      NotLeaderForPartitionError, OffsetAndMessage,
+                      OffsetCommitRequest, OffsetCommitResponse,
+                      OffsetFetchRequest, OffsetFetchResponse, OffsetRequest,
+                      OffsetResponse, PartitionMetadata,
+                      PartitionUnavailableError, ProduceRequest,
+                      ProduceResponse, RequestTimedOutError, TopicAndPartition,
+                      TopicMetadata, UnknownTopicOrPartitionError)
+from ..kafkacodec import KafkaCodec, create_message
 
 log = logging.getLogger(__name__)
 
@@ -87,19 +84,19 @@ def createMetadataResp():
     node_brokers = {
         0: BrokerMetadata(0, "brokers1.afkak.example.com", 1000),
         1: BrokerMetadata(1, "brokers1.afkak.example.com", 1001),
-        3: BrokerMetadata(3, "brokers2.afkak.example.com", 1000)
+        3: BrokerMetadata(3, "brokers2.afkak.example.com", 1000),
     }
 
     topic_partitions = {
         "topic1": TopicMetadata(
             'topic1', 0, {
                 0: PartitionMetadata("topic1", 0, 0, 1, (0, 2), (2,)),
-                1: PartitionMetadata("topic1", 1, 1, 3, (0, 1), (0, 1))
+                1: PartitionMetadata("topic1", 1, 1, 3, (0, 1), (0, 1)),
             },
         ),
         "topic2": TopicMetadata(
             'topic2', 0, {
-                0: PartitionMetadata("topic2", 0, 0, 0, (), ())
+                0: PartitionMetadata("topic2", 0, 0, 0, (), ()),
             },
         ),
         "topic3": TopicMetadata('topic3', 5, {}),
@@ -137,8 +134,7 @@ class TestKafkaClient(unittest.TestCase):
 
     def test_client_bad_timeout(self):
         with self.assertRaises(TypeError):
-            KafkaClient('kafka.example.com', clientId='MyClient',
-                            timeout="100ms")
+            KafkaClient('kafka.example.com', clientId='MyClient', timeout="100ms")
 
     def test_update_cluster_hosts(self):
         c = KafkaClient(hosts='www.example.com')
@@ -154,33 +150,29 @@ class TestKafkaClient(unittest.TestCase):
 
         mocked_brokers = {
             ('kafka01', 9092): MagicMock(connected=lambda: True),
-            ('kafka02', 9092): MagicMock(connected=lambda: False)
+            ('kafka02', 9092): MagicMock(connected=lambda: False),
         }
 
         # inject side effects (makeRequest returns deferreds that are
         # pre-failed with a timeout...
-        mocked_brokers[
-            ('kafka01', 9092)
-            ].makeRequest.side_effect = lambda a, b: fail(
-            RequestTimedOutError("kafka01 went away (unittest)"))
-        mocked_brokers[
-            ('kafka02', 9092)
-            ].makeRequest.side_effect = lambda a, b: fail(
-            RequestTimedOutError("Kafka02 went away (unittest)"))
+        mocked_brokers[('kafka01', 9092)].makeRequest.side_effect = lambda a, b: fail(
+            RequestTimedOutError("kafka01 went away (unittest)"),
+        )
+        mocked_brokers[('kafka02', 9092)].makeRequest.side_effect = lambda a, b: fail(
+            RequestTimedOutError("Kafka02 went away (unittest)"),
+        )
 
         client = KafkaClient(hosts=['kafka01:9092', 'kafka02:9092'])
         # Alter the client's brokerclient dict
         client.clients = mocked_brokers
         client._collect_hosts_d = None
         # Get the deferred (should be already failed)
-        fail1 = client._send_broker_unaware_request(
-            1, 'fake request')
+        fail1 = client._send_broker_unaware_request(1, 'fake request')
         # check it
-        self.successResultOf(
-            self.failUnlessFailure(fail1, KafkaUnavailableError))
+        self.successResultOf(self.failUnlessFailure(fail1, KafkaUnavailableError))
 
         # Check that the proper calls were made
-        for key, brkr in mocked_brokers.items():
+        for _key, brkr in mocked_brokers.items():
             brkr.makeRequest.assert_called_with(1, 'fake request')
 
     def test_send_broker_unaware_request(self):
@@ -193,12 +185,10 @@ class TestKafkaClient(unittest.TestCase):
             ('kafka22', 9092): MagicMock(connected=lambda: False),
         }
         # inject broker side effects
-        mocked_brokers[
-            ('kafka21', 9092)
-            ].makeRequest.side_effect = lambda a, b: fail(
-            RequestTimedOutError("Kafka21 went away (unittest)"))
-        mocked_brokers[('kafka22', 9092)].makeRequest.return_value = \
-            succeed('valid response')
+        mocked_brokers[('kafka21', 9092)].makeRequest.side_effect = lambda a, b: fail(
+            RequestTimedOutError("Kafka21 went away (unittest)"),
+        )
+        mocked_brokers[('kafka22', 9092)].makeRequest.return_value = succeed('valid response')
 
         client = KafkaClient(hosts='kafka21:9092,kafka22:9092')
 
@@ -225,12 +215,10 @@ class TestKafkaClient(unittest.TestCase):
             ('kafka22', 9092): MagicMock(connected=lambda: True),
         }
         # inject broker side effects
-        mocked_brokers[
-            ('kafka21', 9092)
-            ].makeRequest.side_effect = lambda a, b: fail(
-            RequestTimedOutError("Kafka21 went away (unittest)"))
-        mocked_brokers[('kafka22', 9092)].makeRequest.return_value = \
-            succeed('valid response')
+        mocked_brokers[('kafka21', 9092)].makeRequest.side_effect = lambda a, b: fail(
+            RequestTimedOutError("Kafka21 went away (unittest)"),
+        )
+        mocked_brokers[('kafka22', 9092)].makeRequest.return_value = succeed('valid response')
 
         client = KafkaClient(hosts='kafka21:9092,kafka22:9092')
 
@@ -261,8 +249,7 @@ class TestKafkaClient(unittest.TestCase):
         mocked_brokers = {('kafka31', 9092): MagicMock(connected=lambda: True)}
         # inject broker side effects
         mocked_brokers[('kafka31', 9092)].makeRequest.return_value = d
-        mocked_brokers[(
-            'kafka31', 9092)].cancelRequest.side_effect = \
+        mocked_brokers[('kafka31', 9092)].cancelRequest.side_effect = \
             lambda rId, reason: d.errback(reason)
 
         reactor = MemoryReactorClock()
@@ -323,23 +310,19 @@ class TestKafkaClient(unittest.TestCase):
         brokers[1] = BrokerMetadata(2, 'broker_2', 5678)
 
         topics = {}
-        topics['topic_1'] = TopicMetadata(
-            'topic_1', 0, {
-                0: PartitionMetadata('topic_1', 0, 0, 1, [1, 2], [1, 2])
-                })
-        topics['topic_noleader'] = TopicMetadata(
-            'topic_noleader', 0, {
-                0: PartitionMetadata('topic_noleader', 0, 0, -1, [], []),
-                1: PartitionMetadata('topic_noleader', 1, 0, -1, [], [])
-                })
-        topics['topic_no_partitions'] = TopicMetadata('topic_no_partitions',
-                                                      0, {})
-        topics['topic_3'] = TopicMetadata(
-            'topic_3', 0, {
-                0: PartitionMetadata('topic_3', 0, 0, 0, [0, 1], [0, 1]),
-                1: PartitionMetadata('topic_3', 1, 0, 1, [1, 0], [1, 0]),
-                2: PartitionMetadata('topic_3', 2, 0, 0, [0, 1], [0, 1])
-                })
+        topics['topic_1'] = TopicMetadata('topic_1', 0, {
+            0: PartitionMetadata('topic_1', 0, 0, 1, [1, 2], [1, 2]),
+        })
+        topics['topic_noleader'] = TopicMetadata('topic_noleader', 0, {
+            0: PartitionMetadata('topic_noleader', 0, 0, -1, [], []),
+            1: PartitionMetadata('topic_noleader', 1, 0, -1, [], []),
+        })
+        topics['topic_no_partitions'] = TopicMetadata('topic_no_partitions', 0, {})
+        topics['topic_3'] = TopicMetadata('topic_3', 0, {
+            0: PartitionMetadata('topic_3', 0, 0, 0, [0, 1], [0, 1]),
+            1: PartitionMetadata('topic_3', 1, 0, 1, [1, 0], [1, 0]),
+            2: PartitionMetadata('topic_3', 2, 0, 0, [0, 1], [0, 1]),
+        })
         kCodec.decode_metadata_response.return_value = (brokers, topics)
         kCodec.encode_metadata_request.return_value = MagicMock()
 
@@ -432,9 +415,8 @@ class TestKafkaClient(unittest.TestCase):
         brokers[1] = BrokerMetadata(1, 'broker_2', 5678)
 
         topics = {
-            'topic_no_partitions': TopicMetadata(
-                'topic_no_partitions', 0, {})
-            }
+            'topic_no_partitions': TopicMetadata('topic_no_partitions', 0, {}),
+        }
         kCodec.decode_metadata_response.return_value = (brokers, topics)
 
         with patch.object(KafkaClient, '_send_broker_unaware_request',
@@ -469,44 +451,33 @@ class TestKafkaClient(unittest.TestCase):
         brokers[1] = BrokerMetadata(1, 'broker_2', 5678)
 
         topics = {}
-        topics['topic_noleader'] = TopicMetadata(
-            'topic_noleader', 0, {
-                0: PartitionMetadata('topic_noleader', 0, 0, -1, [], []),
-                1: PartitionMetadata('topic_noleader', 1, 0, -1, [], [])
-                })
+        topics['topic_noleader'] = TopicMetadata('topic_noleader', 0, {
+            0: PartitionMetadata('topic_noleader', 0, 0, -1, [], []),
+            1: PartitionMetadata('topic_noleader', 1, 0, -1, [], []),
+        })
         kCodec.decode_metadata_response.return_value = (brokers, topics)
 
         client = KafkaClient(hosts=['broker_1:4567', 'broker_2:5678'],
                              timeout=None)
 
         with patch.object(KafkaClient, '_send_broker_unaware_request',
-                          side_effect=lambda a, b: succeed(
-                              self.testMetaData)):
+                          side_effect=lambda a, b: succeed(self.testMetaData)):
             client._get_leader_for_partition('topic_noleader', 0)
-        self.assertDictEqual(
-            {
-                TopicAndPartition('topic_noleader', 0): None,
-                TopicAndPartition('topic_noleader', 1): None
-            },
-            client.topics_to_brokers)
+        self.assertEqual({
+            TopicAndPartition('topic_noleader', 0): None,
+            TopicAndPartition('topic_noleader', 1): None,
+        }, client.topics_to_brokers)
 
-        self.assertIsNone(
-            self.getLeaderWrapper(client, 'topic_noleader', 0))
-        self.assertIsNone(
-            self.getLeaderWrapper(client, 'topic_noleader', 1))
+        self.assertIsNone(self.getLeaderWrapper(client, 'topic_noleader', 0))
+        self.assertIsNone(self.getLeaderWrapper(client, 'topic_noleader', 1))
 
-        topics['topic_noleader'] = TopicMetadata(
-            'topic_noleader', 0, {
-                0: PartitionMetadata(
-                    'topic_noleader', 0, 0, 0, [0, 1], [0, 1]),
-                1: PartitionMetadata(
-                    'topic_noleader', 1, 0, 1, [1, 0], [1, 0])
-                })
+        topics['topic_noleader'] = TopicMetadata('topic_noleader', 0, {
+            0: PartitionMetadata('topic_noleader', 0, 0, 0, [0, 1], [0, 1]),
+            1: PartitionMetadata('topic_noleader', 1, 0, 1, [1, 0], [1, 0]),
+        })
         kCodec.decode_metadata_response.return_value = (brokers, topics)
-        self.assertEqual(
-            brokers[0], self.getLeaderWrapper(client, 'topic_noleader', 0))
-        self.assertEqual(
-            brokers[1], self.getLeaderWrapper(client, 'topic_noleader', 1))
+        self.assertEqual(brokers[0], self.getLeaderWrapper(client, 'topic_noleader', 0))
+        self.assertEqual(brokers[1], self.getLeaderWrapper(client, 'topic_noleader', 1))
 
     @patch('afkak.client.KafkaCodec')
     def test_send_produce_request_raises_when_noleader(self, kCodec):
@@ -522,12 +493,10 @@ class TestKafkaClient(unittest.TestCase):
         }
 
         topics = {
-            'topic_noleader': TopicMetadata(
-                'topic_noleader', 0, {
-                    0: PartitionMetadata('topic_noleader', 0, 0, -1, [], []),
-                    1: PartitionMetadata('topic_noleader', 1, 0, -1, [], []),
-                }
-            ),
+            'topic_noleader': TopicMetadata('topic_noleader', 0, {
+                0: PartitionMetadata('topic_noleader', 0, 0, -1, [], []),
+                1: PartitionMetadata('topic_noleader', 1, 0, -1, [], []),
+            }),
         }
         kCodec.decode_metadata_response.return_value = (brokers, topics)
 
@@ -783,11 +752,10 @@ class TestKafkaClient(unittest.TestCase):
         with patch.object(kclient, 'log') as klog:
             client._update_broker_state(bkr, False, e)
             self.assertTrue(client._collect_hosts_d)
-            calls = [call('Broker:%r state changed:%s for reason:%r',
-                              'aBroker', 'Disconnected', e),
-                     call('Attempt to fetch Kafka metadata after disconnect '
-                              'failed with: %r', ANY)]
-            self.assertEqual(calls, klog.debug.call_args_list)
+            self.assertEqual([
+                call('Broker:%r state changed:%s for reason:%r', 'aBroker', 'Disconnected', e),
+                call('Attempt to fetch Kafka metadata after disconnect failed with: %r', ANY),
+            ], klog.debug.call_args_list)
         client.reset_all_metadata.assert_called_once_with()
         client.load_metadata_for_topics.assert_called_once_with()
 
@@ -889,16 +857,16 @@ class TestKafkaClient(unittest.TestCase):
         brokers = [
             BrokerMetadata(node_id=1, host='kafka01', port=9092),
             BrokerMetadata(node_id=2, host='kafka02', port=9092),
-            ]
+        ]
         topic_partitions = {
             T1: [0],
             T2: [0],
-            }
+        }
         client.topic_partitions = copy(topic_partitions)
         topics_to_brokers = {
             TopicAndPartition(topic=T1, partition=0): brokers[0],
             TopicAndPartition(topic=T2, partition=0): brokers[1],
-            }
+        }
         client.topics_to_brokers = copy(topics_to_brokers)
 
         # Setup the payloads, encoder & decoder funcs
@@ -909,7 +877,7 @@ class TestKafkaClient(unittest.TestCase):
             ProduceRequest(
                 T2, 0, [create_message(T2.encode() + b" message %d" % i)
                         for i in range(5)]),
-            ]
+        ]
 
         encoder = partial(
             KafkaCodec.encode_produce_request,
@@ -991,19 +959,19 @@ class TestKafkaClient(unittest.TestCase):
         brokers = [
             BrokerMetadata(node_id=1, host='kafka01', port=9092),
             BrokerMetadata(node_id=2, host='kafka02', port=9092),
-            ]
+        ]
         client.topic_partitions = {
             Ts[0]: [0],
             Ts[1]: [0],
             Ts[2]: [0, 1, 2, 3],
             Ts[3]: [],
-            }
+        }
         client.topic_errors = {
             Ts[0]: 0,
             Ts[1]: 0,
             Ts[2]: 0,
             Ts[3]: 5,
-            }
+        }
         client.topics_to_brokers = {
             TopicAndPartition(topic=Ts[0], partition=0): brokers[0],
             TopicAndPartition(topic=Ts[1], partition=0): brokers[1],
@@ -1011,7 +979,7 @@ class TestKafkaClient(unittest.TestCase):
             TopicAndPartition(topic=Ts[2], partition=1): brokers[1],
             TopicAndPartition(topic=Ts[2], partition=2): brokers[0],
             TopicAndPartition(topic=Ts[2], partition=3): brokers[1],
-            }
+        }
 
         # make copies...
         tParts = copy(client.topic_partitions)
@@ -1052,12 +1020,12 @@ class TestKafkaClient(unittest.TestCase):
         brokers = [
             BrokerMetadata(node_id=1, host='kafka01', port=9092),
             BrokerMetadata(node_id=2, host='kafka02', port=9092),
-            ]
+        ]
         client.topic_partitions = {
             Ts[0]: [0],
             Ts[1]: [0],
             Ts[2]: [0, 1, 2, 3],
-            }
+        }
         client.topics_to_brokers = {
             TopicAndPartition(topic=Ts[0], partition=0): brokers[0],
             TopicAndPartition(topic=Ts[1], partition=0): brokers[1],
@@ -1065,7 +1033,7 @@ class TestKafkaClient(unittest.TestCase):
             TopicAndPartition(topic=Ts[2], partition=1): brokers[1],
             TopicAndPartition(topic=Ts[2], partition=2): brokers[0],
             TopicAndPartition(topic=Ts[2], partition=3): brokers[1],
-            }
+        }
 
         for topic in Ts:
             self.assertTrue(client.has_metadata_for_topic(topic))
@@ -1081,12 +1049,12 @@ class TestKafkaClient(unittest.TestCase):
         brokers = [
             BrokerMetadata(node_id=1, host='kafka01', port=9092),
             BrokerMetadata(node_id=2, host='kafka02', port=9092),
-            ]
+        ]
         client.topic_partitions = {
             Ts[0]: [0],
             Ts[1]: [0],
             Ts[2]: [0, 1, 2, 3],
-            }
+        }
         client.topics_to_brokers = {
             TopicAndPartition(topic=Ts[0], partition=0): brokers[0],
             TopicAndPartition(topic=Ts[1], partition=0): brokers[1],
@@ -1094,11 +1062,10 @@ class TestKafkaClient(unittest.TestCase):
             TopicAndPartition(topic=Ts[2], partition=1): brokers[1],
             TopicAndPartition(topic=Ts[2], partition=2): brokers[0],
             TopicAndPartition(topic=Ts[2], partition=3): brokers[1],
-            }
+        }
         client.consumer_group_to_brokers = {
-            u'ConsumerGroup1': BrokerMetadata(
-                node_id=0, host='host1', port=9092)
-            }
+            u'ConsumerGroup1': BrokerMetadata(node_id=0, host='host1', port=9092),
+        }
 
         for topic in Ts:
             self.assertTrue(client.has_metadata_for_topic(topic))
@@ -1133,7 +1100,6 @@ class TestKafkaClient(unittest.TestCase):
         self.assertNoResult(close_d)
         mb2.close.return_value.callback(UserError())
         self.assertEqual(None, self.successResultOf(close_d))
-
 
     def test_client_close_no_clients(self):
         client = KafkaClient(hosts=[])
@@ -1180,7 +1146,7 @@ class TestKafkaClient(unittest.TestCase):
             struct.pack('>i', 4),           # Correlation ID
             struct.pack('>h', 0),           # Error Code
             struct.pack('>i', 0),           # Coordinator id
-            struct.pack('>h', len(b"host1")), b"host1", # The Coordinator host
+            struct.pack('>h', len(b"host1")), b"host1",  # The Coordinator host
             struct.pack('>i', 9092),          # The Coordinator port
         ])
         request_ds = [Deferred(), Deferred(), Deferred()]
@@ -1199,11 +1165,9 @@ class TestKafkaClient(unittest.TestCase):
             # Now 'send' a response to the first/3rd requests
             request_ds[0].callback(response)
             # And check the client's consumer metadata got properly updated
-            self.assertEqual(
-                client.consumer_group_to_brokers,
-                {u'ConsumerGroup1': BrokerMetadata(
-                    node_id=0, host='host1', port=9092)}
-                )
+            self.assertEqual({
+                u'ConsumerGroup1': BrokerMetadata(node_id=0, host='host1', port=9092),
+            }, client.consumer_group_to_brokers)
 
             # After response, new request for same group gets new deferred
             load4_d = client.load_consumer_metadata_for_group(G1)
@@ -1266,9 +1230,10 @@ class TestKafkaClient(unittest.TestCase):
             ('kafka32', 9092): MagicMock(),
         }
         # inject broker side effects
-        ds = [[Deferred(), Deferred(), Deferred(), Deferred(), ],
-              [Deferred(), Deferred(), Deferred(), Deferred(), ],
-              ]
+        ds = [
+            [Deferred(), Deferred(), Deferred(), Deferred()],
+            [Deferred(), Deferred(), Deferred(), Deferred()],
+        ]
         mocked_brokers[('kafka31', 9092)].makeRequest.side_effect = ds[0]
         mocked_brokers[('kafka32', 9092)].makeRequest.side_effect = ds[1]
 
@@ -1281,15 +1246,15 @@ class TestKafkaClient(unittest.TestCase):
         brokers = [
             BrokerMetadata(node_id=1, host='kafka31', port=9092),
             BrokerMetadata(node_id=2, host='kafka32', port=9092),
-            ]
+        ]
         client.topic_partitions = {
             T1: [0],
             T2: [0],
-            }
+        }
         client.topics_to_brokers = {
             TopicAndPartition(topic=T1, partition=0): brokers[0],
             TopicAndPartition(topic=T2, partition=0): brokers[1],
-            }
+        }
 
         # Setup the payloads
         payloads = [
@@ -1297,13 +1262,13 @@ class TestKafkaClient(unittest.TestCase):
                 topic=T1,
                 partition=0,
                 messages=[create_message("{} message {}".format(T1, i).encode('ascii'))
-                          for i in range(10)]
+                          for i in range(10)],
             ),
             ProduceRequest(
                 topic=T2,
                 partition=0,
                 messages=[create_message("{} message {}".format(T2, i).encode('ascii'))
-                          for i in range(5)]
+                          for i in range(5)],
             ),
         ]
 
@@ -1394,9 +1359,10 @@ class TestKafkaClient(unittest.TestCase):
             ('kafka42', 9092): MagicMock(),
         }
         # inject broker side effects
-        ds = [[Deferred(), Deferred(), Deferred(), Deferred(), ],
-              [Deferred(), Deferred(), Deferred(), Deferred(), ],
-              ]
+        ds = [
+            [Deferred(), Deferred(), Deferred(), Deferred()],
+            [Deferred(), Deferred(), Deferred(), Deferred()],
+        ]
         mocked_brokers[('kafka41', 9092)].makeRequest.side_effect = ds[0]
         mocked_brokers[('kafka42', 9092)].makeRequest.side_effect = ds[1]
 
@@ -1409,20 +1375,18 @@ class TestKafkaClient(unittest.TestCase):
         brokers = [
             BrokerMetadata(node_id=1, host='kafka41', port=9092),
             BrokerMetadata(node_id=2, host='kafka42', port=9092),
-            ]
+        ]
         client.topic_partitions = {
             T1: [0],
             T2: [0],
-            }
+        }
         client.topics_to_brokers = {
             TopicAndPartition(topic=T1, partition=0): brokers[0],
             TopicAndPartition(topic=T2, partition=0): brokers[1],
-            }
+        }
 
         # Setup the payloads
-        payloads = [FetchRequest(T1, 0, 0, 1024),
-                    FetchRequest(T2, 0, 0, 1024),
-                    ]
+        payloads = [FetchRequest(T1, 0, 0, 1024), FetchRequest(T2, 0, 0, 1024)]
 
         # patch the client so we control the brokerclients
         with patch.object(KafkaClient, '_get_brokerclient',
@@ -1476,7 +1440,7 @@ class TestKafkaClient(unittest.TestCase):
         ds[1][1].callback(encoded)
         # check the results
         results = list(self.successResultOf(respD))
-        expanded_responses = [expand_messages(r) for r in  results]
+        expanded_responses = [expand_messages(r) for r in results]
         expect = [FetchResponse(T1, 0, 0, 10, [OffsetAndMessage(0, msgs[0]),
                                                OffsetAndMessage(1, msgs[1])]),
                   FetchResponse(T2, 0, 0, 30, [OffsetAndMessage(48, msgs[3]),
@@ -1501,9 +1465,10 @@ class TestKafkaClient(unittest.TestCase):
             ('kafka52', 9092): MagicMock(),
         }
         # inject broker side effects
-        ds = [[Deferred(), Deferred(), Deferred(), Deferred(), ],
-              [Deferred(), Deferred(), Deferred(), Deferred(), ],
-              ]
+        ds = [
+            [Deferred(), Deferred(), Deferred(), Deferred()],
+            [Deferred(), Deferred(), Deferred(), Deferred()],
+        ]
         mocked_brokers[('kafka51', 9092)].makeRequest.side_effect = ds[0]
         mocked_brokers[('kafka52', 9092)].makeRequest.side_effect = ds[1]
 
@@ -1516,20 +1481,21 @@ class TestKafkaClient(unittest.TestCase):
         brokers = [
             BrokerMetadata(node_id=1, host='kafka51', port=9092),
             BrokerMetadata(node_id=2, host='kafka52', port=9092),
-            ]
+        ]
         client.topic_partitions = {
             T1: [0],
             T2: [0],
-            }
+        }
         client.topics_to_brokers = {
             TopicAndPartition(topic=T1, partition=0): brokers[0],
             TopicAndPartition(topic=T2, partition=0): brokers[1],
-            }
+        }
 
         # Setup the payloads
-        payloads = [OffsetRequest(T1, 0, -1, 20),  # ask for up to 20
-                    OffsetRequest(T2, 0, -2, 1),  # -2==earliest, only get 1
-                    ]
+        payloads = [
+            OffsetRequest(T1, 0, -1, 20),  # ask for up to 20
+            OffsetRequest(T2, 0, -2, 1),  # -2==earliest, only get 1
+        ]
 
         # patch the client so we control the brokerclients
         with patch.object(KafkaClient, '_get_brokerclient',
@@ -1568,10 +1534,8 @@ class TestKafkaClient(unittest.TestCase):
         # check the results
         results = list(self.successResultOf(respD))
         self.assertEqual(set(results), set([
-            OffsetResponse(topic=T1, partition=0, error=0,
-                           offsets=(96, 98, 99,)),
-            OffsetResponse(topic=T2, partition=0, error=0,
-                           offsets=(4096,)),
+            OffsetResponse(topic=T1, partition=0, error=0, offsets=(96, 98, 99)),
+            OffsetResponse(topic=T2, partition=0, error=0, offsets=(4096,)),
         ]))
 
         # Again, with a callback
@@ -1587,10 +1551,8 @@ class TestKafkaClient(unittest.TestCase):
         # check the results
         results = list(self.successResultOf(respD))
         self.assertEqual(set(results), set([
-            OffsetResponse(topic=T1, partition=0, error=0,
-                           offsets=(96, 98, 99,)),
-            OffsetResponse(topic=T2, partition=0, error=0,
-                           offsets=(4096,)),
+            OffsetResponse(topic=T1, partition=0, error=0, offsets=(96, 98, 99)),
+            OffsetResponse(topic=T2, partition=0, error=0, offsets=(4096,)),
         ]))
 
     def test_send_offset_fetch_request(self):
@@ -1605,9 +1567,10 @@ class TestKafkaClient(unittest.TestCase):
         }
 
         # inject broker side effects
-        ds = [[Deferred(), Deferred(), Deferred(), Deferred(), ],
-              [Deferred(), Deferred(), Deferred(), Deferred(), ],
-              ]
+        ds = [
+            [Deferred(), Deferred(), Deferred(), Deferred()],
+            [Deferred(), Deferred(), Deferred(), Deferred()],
+        ]
 
         mocked_brokers[('kafka71', 9092)].makeRequest.side_effect = ds[0]
         mocked_brokers[('kafka72', 9092)].makeRequest.side_effect = ds[1]
@@ -1615,11 +1578,11 @@ class TestKafkaClient(unittest.TestCase):
         brokers = [
             BrokerMetadata(node_id=1, host='kafka71', port=9092),
             BrokerMetadata(node_id=2, host='kafka72', port=9092),
-            ]
+        ]
         broker_for_group = {
             G1: brokers[0],
             G2: brokers[1],
-            }
+        }
 
         def mock_get_brkr(host, port):
             return mocked_brokers[(nativeString(host), port)]
@@ -1719,9 +1682,10 @@ class TestKafkaClient(unittest.TestCase):
         }
 
         # inject broker side effects
-        ds = [[Deferred(), Deferred(), Deferred(), Deferred(), ],
-              [Deferred(), Deferred(), Deferred(), Deferred(), ],
-              ]
+        ds = [
+            [Deferred(), Deferred(), Deferred(), Deferred()],
+            [Deferred(), Deferred(), Deferred(), Deferred()],
+        ]
 
         mocked_brokers[('kafka71', 9092)].makeRequest.side_effect = ds[0]
         mocked_brokers[('kafka72', 9092)].makeRequest.side_effect = ds[1]
@@ -1729,11 +1693,11 @@ class TestKafkaClient(unittest.TestCase):
         brokers = [
             BrokerMetadata(node_id=1, host='kafka71', port=9092),
             BrokerMetadata(node_id=2, host='kafka72', port=9092),
-            ]
+        ]
         broker_for_group = {
             G1: brokers[0],
             G2: brokers[1],
-            }
+        }
 
         def mock_get_brkr(host, port):
             return mocked_brokers[(nativeString(host), port)]
@@ -1794,9 +1758,10 @@ class TestKafkaClient(unittest.TestCase):
             ('kafka62', 9092): MagicMock(),
         }
         # inject broker side effects
-        ds = [[Deferred(), Deferred(), Deferred(), Deferred(), ],
-              [Deferred(), Deferred(), Deferred(), Deferred(), ],
-              ]
+        ds = [
+            [Deferred(), Deferred(), Deferred(), Deferred()],
+            [Deferred(), Deferred(), Deferred(), Deferred()],
+        ]
 
         mocked_brokers[('kafka61', 9092)].makeRequest.side_effect = ds[0]
         mocked_brokers[('kafka62', 9092)].makeRequest.side_effect = ds[1]
@@ -1804,11 +1769,11 @@ class TestKafkaClient(unittest.TestCase):
         brokers = [
             BrokerMetadata(node_id=1, host='kafka61', port=9092),
             BrokerMetadata(node_id=2, host='kafka62', port=9092),
-            ]
+        ]
         broker_for_group = {
             G1: brokers[0],
             G2: brokers[1],
-            }
+        }
 
         def mock_get_brkr(host, port):
             return mocked_brokers[(nativeString(host), port)]
@@ -1825,17 +1790,17 @@ class TestKafkaClient(unittest.TestCase):
         client.topic_partitions = {
             T1: [61],
             T2: [62],
-            }
+        }
         client.topics_to_brokers = {
             TopicAndPartition(topic=T1, partition=61): brokers[0],
             TopicAndPartition(topic=T2, partition=62): brokers[1],
-            }
+        }
 
         # Setup the payloads
         payloads = [
             OffsetCommitRequest(T1, 61, 81, -1, b"metadata1"),
             OffsetCommitRequest(T2, 62, 91, -1, b"metadata2"),
-            ]
+        ]
 
         # patch the client so we control the brokerclients
         with patch.object(KafkaClient, '_get_brokerclient',
@@ -1885,12 +1850,12 @@ class TestKafkaClient(unittest.TestCase):
         # Setup the client with the metadata we want it to have
         client.topic_partitions = {
             T1: [61],
-            }
+        }
 
         # Setup the payloads
         payloads = [
             OffsetCommitRequest(T1, 61, 81, -1, b"metadata1"),
-            ]
+        ]
 
         respD1 = client.send_offset_commit_request(G1, [])
         self.assertTrue(
@@ -1914,10 +1879,9 @@ class TestKafkaClient(unittest.TestCase):
 
         # inject side effects (makeRequest returns deferreds that are
         # pre-failed with a timeout...
-        mocked_brokers[
-            ('kafka01', 9092)
-            ].makeRequest.side_effect = lambda a, b: fail(
-            RequestTimedOutError("kafka01 went away (unittest)"))
+        mocked_brokers[('kafka01', 9092)].makeRequest.side_effect = lambda a, b: fail(
+            RequestTimedOutError("kafka01 went away (unittest)"),
+        )
 
         client = KafkaClient(hosts=['kafka01:9092'])
         # Alter the client's brokerclient dict
@@ -1935,7 +1899,7 @@ class TestKafkaClient(unittest.TestCase):
             self.assertTrue(client._collect_hosts_d)
 
             # Check that the proper calls were made
-            for key, brkr in mocked_brokers.items():
+            for _key, brkr in mocked_brokers.items():
                 brkr.makeRequest.assert_called_with(1, b'fake request')
 
             # Patch the lookup and retry the request
@@ -1970,8 +1934,7 @@ class TestKafkaClient(unittest.TestCase):
         m.configure_mock(host='kafka_dot', port=9092)
 
         reactor = MemoryReactorClock()
-        client = KafkaClient(hosts='kafka_dot:9092', reactor=reactor,
-                                 disconnect_on_timeout=False)
+        client = KafkaClient(hosts='kafka_dot:9092', reactor=reactor, disconnect_on_timeout=False)
 
         # Alter the client's brokerclient dict to use our mocked broker
         client.clients = mocked_brokers
@@ -2008,8 +1971,7 @@ class TestKafkaClient(unittest.TestCase):
         m.configure_mock(host='kafka_dot', port=9092)
 
         reactor = MemoryReactorClock()
-        client = KafkaClient(hosts='kafka_dot:9092', reactor=reactor,
-                                 disconnect_on_timeout=True)
+        client = KafkaClient(hosts='kafka_dot:9092', reactor=reactor, disconnect_on_timeout=True)
 
         # Alter the client's brokerclient dict to use our mocked broker
         client.clients = mocked_brokers
@@ -2041,7 +2003,7 @@ class TestKafkaClient(unittest.TestCase):
             'Topic0': [],  # No partitions.
             'Topic2': [0],  # Not in partition_meta below
             'Topic3': [0, 1, 2, 3],  # "Good" partition
-            }
+        }
         client.partition_meta = {
             TopicAndPartition(topic='Topic3', partition=0):
                 PartitionMetadata('Topic3', 0, 0, 1, [1, 2], [1, 2]),
@@ -2051,7 +2013,7 @@ class TestKafkaClient(unittest.TestCase):
                 PartitionMetadata('Topic3', 2, 0, 1, [1, 2], [1, 2]),
             TopicAndPartition(topic='Topic3', partition=3):
                 PartitionMetadata('Topic3', 3, 0, 2, [2, 1], [1, 2]),
-            }
+        }
 
         # Topics which don't have partitions aren't 'fully replicated'
         self.assertFalse(client.topic_fully_replicated('Topic0'))

--- a/afkak/test/test_performance_integration.py
+++ b/afkak/test/test_performance_integration.py
@@ -1,38 +1,24 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2017 Ciena, Inc.
+# Copyright 2017, 2018 Ciena Corporation.
 
 from __future__ import print_function
 
+import logging
 import os
 import sys
-import logging
-from random import randint
 import time
+from random import randint
 
-from nose.twistedtools import threaded_reactor, deferred
-from twisted.internet.defer import inlineCallbacks, returnValue
+from nose.twistedtools import deferred, threaded_reactor
+from twisted.internet.defer import inlineCallbacks
 from twisted.trial import unittest
 
-from afkak import (
-    Consumer, create_message,
-    create_message_set, Producer,
-    RoundRobinPartitioner, HashedPartitioner,
-    CODEC_GZIP, CODEC_SNAPPY,
-    )
-from afkak.common import (
-    ProduceRequest, ConsumerFetchSizeTooSmall,
-    OFFSET_EARLIEST, OFFSET_COMMITTED,
-    PRODUCER_ACK_NOT_REQUIRED,
-    PRODUCER_ACK_ALL_REPLICAS,
-    PRODUCER_ACK_LOCAL_WRITE,
-    )
-from afkak.codec import has_snappy
-from afkak.consumer import FETCH_BUFFER_SIZE_BYTES
-from .fixtures import ZookeeperFixture, KafkaFixture
-from .testutil import (
-    kafka_versions, KafkaIntegrationTestCase, async_delay,
-    random_string, make_send_requests, stat
-    )
+from .. import Consumer, Producer
+from ..common import OFFSET_EARLIEST
+from ..consumer import FETCH_BUFFER_SIZE_BYTES
+from .fixtures import KafkaFixture, ZookeeperFixture
+from .testutil import (KafkaIntegrationTestCase, async_delay, kafka_versions,
+                       random_string, stat)
 
 log = logging.getLogger(__name__)
 
@@ -99,7 +85,8 @@ class TestPerformanceIntegration(KafkaIntegrationTestCase, unittest.TestCase):
                 random_string(1024) for x in range(MESSAGE_BLOCK_SIZE)]]
         large_messages = [
             self.msg(s) for s in [random_string(FETCH_BUFFER_SIZE_BYTES * 3)
-                for x in range(MESSAGE_BLOCK_SIZE)]]
+                                  for x in range(MESSAGE_BLOCK_SIZE)]
+        ]
 
         constant_messages_size = len(constant_messages[0]) * MESSAGE_BLOCK_SIZE
         large_messages_size = len(large_messages[0]) * MESSAGE_BLOCK_SIZE
@@ -109,7 +96,7 @@ class TestPerformanceIntegration(KafkaIntegrationTestCase, unittest.TestCase):
 
         # Create consumers (1/partition)
         consumers = [self.consumer(partition=p, fetch_max_wait_time=50)
-                         for p in range(PARTITION_COUNT)]
+                     for p in range(PARTITION_COUNT)]
 
         def log_error(failure):
             log.exception("Failure sending messages: %r", failure)  # pragma: no cover
@@ -122,24 +109,22 @@ class TestPerformanceIntegration(KafkaIntegrationTestCase, unittest.TestCase):
         def send_msgs():
             # randomly, 1/20 of the time, send large messages
             if randint(0, 19):
-            ## if True:
                 messages = constant_messages
-                large=''
+                large = ''
                 total_messages_size[0] += constant_messages_size
             else:
                 messages = large_messages
-                large=' large'
+                large = ' large'
                 total_messages_size[0] += large_messages_size
 
             log.info("Sending: %d%s messages", len(messages), large)
-            d = producer.send_messages(self.topic,
-                msgs=messages)
+            d = producer.send_messages(self.topic, msgs=messages)
             # As soon as we get a response from the broker, count them
             # and if we're still supposed to, send more
             d.addCallback(sent_msgs)
             if keep_running:
                 d.addCallback(lambda _: self.reactor.callLater(0, send_msgs))
-                ## d.addCallback(lambda _: send_msgs())
+                # d.addCallback(lambda _: send_msgs())
             d.addErrback(log_error)
 
         # Start sending messages, MESSAGE_BLOCK_SIZE at a time, 1K or 384K each
@@ -147,8 +132,7 @@ class TestPerformanceIntegration(KafkaIntegrationTestCase, unittest.TestCase):
 
         # Start the consumers from the beginning
         fetch_start = time.time()
-        start_ds = [consumer.start(OFFSET_EARLIEST)
-                        for consumer in consumers]
+        start_ds = [consumer.start(OFFSET_EARLIEST) for consumer in consumers]
 
         # Let them all run for awhile...
         log.info("Waiting %d seconds...", PRODUCE_TIME)
@@ -156,26 +140,23 @@ class TestPerformanceIntegration(KafkaIntegrationTestCase, unittest.TestCase):
         # Tell the producer to stop
         keep_running = False
         # Wait up to PRODUCE_TIME for the consumers to catch up
-        log.info("Waiting up to %d seconds for "
-                     "consumers to finish consuming...", PRODUCE_TIME)
+        log.info("Waiting up to %d seconds for consumers to finish consuming...", PRODUCE_TIME)
         deadline = time.time() + PRODUCE_TIME * 2
         while time.time() < deadline:
-            consumed = sum([len(consumer.processor._messages)
-                                              for consumer in consumers])
+            consumed = sum([len(consumer.processor._messages) for consumer in consumers])
             log.debug("Consumed %d messages.", consumed)
             if sent_msgs_count[0] == consumed:
                 break
             yield async_delay(1)
         fetch_time = time.time() - fetch_start
-        consumed_bytes = sum([c.processor._messages_bytes[0]
-                                  for c in consumers])
+        consumed_bytes = sum([c.processor._messages_bytes[0] for c in consumers])
 
         result_msg = (
             "Sent: {} messages ({:,} total bytes) in ~{} seconds"
             " ({}/sec), Consumed: {} in {:.2f} seconds."
-            .format(sent_msgs_count[0], total_messages_size[0],
-                        PRODUCE_TIME, sent_msgs_count[0]/PRODUCE_TIME,
-                        consumed, fetch_time))
+        ).format(sent_msgs_count[0], total_messages_size[0],
+                 PRODUCE_TIME, sent_msgs_count[0] / PRODUCE_TIME,
+                 consumed, fetch_time)
         # Log the result, and print to stderr to get around nose capture
         log.info(result_msg)
         print("\n\t Performance Data: " + result_msg, file=sys.stderr)
@@ -186,11 +167,10 @@ class TestPerformanceIntegration(KafkaIntegrationTestCase, unittest.TestCase):
         stat('Messages_Consumed', consumed)
         stat('Messages_Bytes_Produced', total_messages_size[0])
         stat('Messages_Bytes_Consumed', consumed_bytes)
-        stat('Messages_Produced_Per_Second', sent_msgs_count[0]/PRODUCE_TIME)
-        stat('Messages_Consumed_Per_Second', consumed/fetch_time)
-        stat('Message_Bytes_Produced_Per_Second',
-                 total_messages_size[0]/PRODUCE_TIME)
-        stat('Message_Bytes_Consumed_Per_Second', consumed_bytes/fetch_time)
+        stat('Messages_Produced_Per_Second', sent_msgs_count[0] / PRODUCE_TIME)
+        stat('Messages_Consumed_Per_Second', consumed / fetch_time)
+        stat('Message_Bytes_Produced_Per_Second', total_messages_size[0] / PRODUCE_TIME)
+        stat('Message_Bytes_Consumed_Per_Second', consumed_bytes / fetch_time)
 
         # Clean up
         log.debug('Stopping producer: %r', producer)
@@ -200,9 +180,7 @@ class TestPerformanceIntegration(KafkaIntegrationTestCase, unittest.TestCase):
             consumer.stop()
         [self.successResultOf(start_d) for start_d in start_ds]
         # make sure we got all the messages we sent
-        self.assertEqual(sent_msgs_count[0],
-                         sum([len(consumer.processor._messages)
-                                  for consumer in consumers]))
+        self.assertEqual(sent_msgs_count[0], sum([len(consumer.processor._messages) for consumer in consumers]))
         # self.fail("Failing so Nose will emit logging.")
 
     def consumer(self, **kwargs):

--- a/afkak/test/test_producer.py
+++ b/afkak/test/test_producer.py
@@ -5,37 +5,25 @@
 import logging
 import uuid
 
-from mock import Mock, ANY, patch, call
-
-from twisted.python.failure import Failure
-from twisted.internet.defer import (
-    Deferred, fail, succeed,
-    CancelledError as tid_CancelledError
-    )
+from mock import ANY, Mock, call, patch
+import six
+from twisted.internet.defer import CancelledError as tid_CancelledError
+from twisted.internet.defer import Deferred, fail, succeed
 from twisted.internet.task import LoopingCall
+from twisted.python.failure import Failure
 from twisted.test.proto_helpers import MemoryReactorClock
 from twisted.trial import unittest
 
-from afkak.producer import (Producer)
-import afkak.producer as aProducer
-
-from afkak.common import (
-    ProduceRequest,
-    ProduceResponse,
-    UnsupportedCodecError,
-    UnknownTopicOrPartitionError,
-    OffsetOutOfRangeError,
-    BrokerNotAvailableError,
-    NotLeaderForPartitionError,
-    LeaderNotAvailableError,
-    NoResponseError,
-    FailedPayloadsError,
-    CancelledError,
-    PRODUCER_ACK_NOT_REQUIRED,
-    )
-
-from afkak.kafkacodec import (create_message_set)
-from .testutil import (random_string, make_send_requests)
+from .. import producer as aProducer
+from ..common import (PRODUCER_ACK_NOT_REQUIRED, BrokerNotAvailableError,
+                      CancelledError, FailedPayloadsError,
+                      LeaderNotAvailableError, NoResponseError,
+                      NotLeaderForPartitionError, OffsetOutOfRangeError,
+                      ProduceRequest, ProduceResponse,
+                      UnknownTopicOrPartitionError, UnsupportedCodecError)
+from ..kafkacodec import create_message_set
+from ..producer import Producer
+from .testutil import make_send_requests, random_string
 
 log = logging.getLogger(__name__)
 
@@ -62,7 +50,7 @@ class ProducerSendMessagesValidationTests(unittest.SynchronousTestCase):
         """
         `TypeError` results when the *topic* argument is a bytestring on Python 3.
         """
-        if type('') is type(b''):
+        if six.PY3:
             raise unittest.SkipTest('str is bytes on Python 2')
         self.failureResultOf(self.producer.send_messages(b'topic', msgs=[b'']), TypeError)
 
@@ -97,7 +85,6 @@ class ProducerSendMessagesValidationTests(unittest.SynchronousTestCase):
         The key must not be unicode, but bytes.
         """
         self.failureResultOf(self.producer.send_messages('topic', key=u'key', msgs=[b'msg']), TypeError)
-
 
 
 class TestAfkakProducer(unittest.TestCase):

--- a/afkak/test/test_util.py
+++ b/afkak/test/test_util.py
@@ -12,19 +12,19 @@ class TestUtil(unittest.TestCase):
     def test_write_int_string(self):
         self.assertEqual(
             afkak.util.write_int_string(b'some string'),
-            b'\x00\x00\x00\x0bsome string'
+            b'\x00\x00\x00\x0bsome string',
         )
 
     def test_write_int_string__empty(self):
         self.assertEqual(
             afkak.util.write_int_string(b''),
-            b'\x00\x00\x00\x00'
+            b'\x00\x00\x00\x00',
         )
 
     def test_write_int_string__null(self):
         self.assertEqual(
             afkak.util.write_int_string(None),
-            b'\xff\xff\xff\xff'
+            b'\xff\xff\xff\xff',
         )
 
     def test_read_int_string(self):
@@ -48,19 +48,19 @@ class TestUtil(unittest.TestCase):
     def test_write_short_bytes(self):
         self.assertEqual(
             afkak.util.write_short_bytes(b'some string'),
-            b'\x00\x0bsome string'
+            b'\x00\x0bsome string',
         )
 
     def test_write_short_bytes__empty(self):
         self.assertEqual(
             afkak.util.write_short_bytes(b''),
-            b'\x00\x00'
+            b'\x00\x00',
         )
 
     def test_write_short_bytes__null(self):
         self.assertEqual(
             afkak.util.write_short_bytes(None),
-            b'\xff\xff'
+            b'\xff\xff',
         )
 
     def test_write_short_bytes__too_long(self):
@@ -87,7 +87,7 @@ class TestUtil(unittest.TestCase):
     def test_relative_unpack(self):
         self.assertEqual(
             afkak.util.relative_unpack('>hh', b'\x00\x01\x00\x00\x02', 0),
-            ((1, 0), 4)
+            ((1, 0), 4),
         )
 
     def test_relative_unpack__insufficient_data(self):
@@ -97,7 +97,7 @@ class TestUtil(unittest.TestCase):
     def test_group_by_topic_and_partition(self):
         t = afkak.common.TopicAndPartition
 
-        l = [
+        lst = [
             t("a", 1),
             t("a", 1),
             t("a", 2),
@@ -105,7 +105,7 @@ class TestUtil(unittest.TestCase):
             t("b", 3),
         ]
 
-        self.assertEqual(afkak.util.group_by_topic_and_partition(l), {
+        self.assertEqual(afkak.util.group_by_topic_and_partition(lst), {
             "a": {
                 1: t("a", 1),
                 2: t("a", 2),
@@ -113,5 +113,5 @@ class TestUtil(unittest.TestCase):
             },
             "b": {
                 3: t("b", 3),
-            }
+            },
         })

--- a/afkak/test/testutil.py
+++ b/afkak/test/testutil.py
@@ -56,16 +56,16 @@ def async_delay(timeout=0.01, clock=None):
     return d
 
 
-def random_string(l):
+def random_string(length):
     # Random.choice can be very slow for large amounts of data, so 'cheat'
-    if l <= 50:
-        s = "".join(random.choice(string.ascii_letters) for i in range(l))
+    if length <= 50:
+        s = "".join(random.choice(string.ascii_letters) for _i in range(length))
     else:
         r = random_string(50)
-        s = "".join(r for i in range(l // 50))
-        if l % 50:
-            s += r[0:(l % 50)]
-    assert len(s) == l
+        s = "".join(r for i in range(length // 50))
+        if length % 50:
+            s += r[0:(length % 50)]
+    assert len(s) == length
     return s
 
 
@@ -108,10 +108,9 @@ def ensure_topic_creation(
     def topic_info():
         if topic_name in client.topic_partitions:
             return "Topic {} exists. Partition metadata: {}".format(
-                topic_name, pformat([
-                client.partition_meta[TopicAndPartition(topic_name, part)]
-                for part in client.topic_partitions[topic_name]
-            ]))
+                topic_name, pformat([client.partition_meta[TopicAndPartition(topic_name, part)]
+                                     for part in client.topic_partitions[topic_name]]),
+            )
         else:
             return "No metadata for topic {} found.".format(topic_name)
 

--- a/tox.ini
+++ b/tox.ini
@@ -123,5 +123,4 @@ commands =
 doctests = yes
 max-line-length = 120
 enable = E124
-max-complexity = 10
 jobs = auto

--- a/tox.ini
+++ b/tox.ini
@@ -122,6 +122,6 @@ commands =
 [flake8]
 doctests = yes
 max-line-length = 120
-select = E124
+enable = E124
 max-complexity = 10
 jobs = auto


### PR DESCRIPTION
So... it looks like I actually removed all the effective linting when I removed `pyflakes` from the Makefile, as the flake8 configuration had the line `select = E124`. This enables _only_ the E124 check, disabling all the rest! I changed this to `enable = E124` and fixed all the linting errors.

I also removed mccabe cyclomatic complexity checking, as I find it more frustrating than useful in Twisted code (it interacts poorly with inner functions).