### PR TITLE
Fix test_failover_integration failures again

### DIFF
--- a/afkak/test/fixtures.py
+++ b/afkak/test/fixtures.py
@@ -144,6 +144,7 @@ class KafkaFixture(Fixture):
 
         self.replicas = replicas
         self.partitions = partitions
+        assert replicas % 2 == 1, "replica count must be odd, not {}".format(replicas)
         self.min_insync_replicas = replicas // 2 + 1
 
         self.message_max_bytes = message_max_bytes


### PR DESCRIPTION
Short version: the test ran two Kafka brokers with num.replicas=2 and
min.insync.replicas=2, so producing always failed when it took a broker
down. This was fixed by increasing the number of brokers and
num.replicas to 3. min.insync.replicas remains 2 per the formula:

    min.insync.replicas = (num.replicas // 2) + 1

Additionally, the assertion about the number of messages produced
and consumed matching was erroneous — the number of messages consumed
must be _at least_ the number of messages produced (due to retries,
partial failures, etc. messages may be duplicated).

These failures mostly seemed to appear on my (fast) desktop, unlike the
failures on slow Travis CI in #22.