### PR TITLE
flake8-isort config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -137,9 +137,6 @@ known_third_party =
     twisted
     zope
     __pypy__
-known_first_party =
-    hookworm
-    twigjack
 use_parenthesis = true
 multi_line_output = 5
 include_trailing_comma = true

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,8 @@ deps =
     nose-timer==0.5.0
     Twisted==17.9.0
     lint: flake8
+    ; TODO Enable flake8-isort once all files are clean.
+    ; lint: flake8-isort==2.5
     pylint: pylint
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -124,3 +124,20 @@ doctests = yes
 max-line-length = 120
 enable = E124
 jobs = auto
+
+[isort]
+known_third_party =
+    attr
+    murmur
+    nose
+    pyhash
+    six
+    twisted
+    zope
+    __pypy__
+known_first_party =
+    hookworm
+    twigjack
+use_parenthesis = true
+multi_line_output = 5
+include_trailing_comma = true


### PR DESCRIPTION
Add configuration for [flake8-isort](https://pypi.org/project/flake8-isort/), but don't enforce it in the build yet. I have it enabled in my editor so this will eventually result compliance across the codebase. Making these changes immediately will cause too many conflicts with outstanding PRs.