### PR TITLE
Make Message repr truncate value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,10 @@
 Version 3.0.0.dev0
 ------------------
 
-* Added `auto_offset_reset` parameter to Consumer objects which allows the 
+* Added `auto_offset_reset` parameter to Consumer objects which allows the
   caller to auto reset offset on `OffsetOutOfRange` error.
   NOTE: It defaults to `None` which indicates to raise the error.
-  
+
 * Python 3 compatibility.
 
 * **Backwards incompatible:** Afkak is now more particular about string types.
@@ -13,6 +13,10 @@ Version 3.0.0.dev0
   Message content and commit metadata are bytes — `bytes` on Python 3; `str` on Python 2.
 
 * The new ``snappy`` setuptools extra pulls in python-snappy, which is required for Snappy compression support.
+
+* **Backwards incompatible:** The constants ``CODEC_NONE``, ``CODEC_GZIP``, and ``CODEC_SNAPPY`` have been relocated to the ``afkak.common`` module from the ``afkak.kafkacodec`` module.
+  They remain importable directly from the ``afkak`` module.
+  The ``ALL_CODECS`` constant is no longer available.
 
 * The way reactors are passed around has been unified.
   `KafkaClient` now has a public `reactor` attribute which is used by `Producer` and `Consumer`.

--- a/afkak/__init__.py
+++ b/afkak/__init__.py
@@ -5,14 +5,14 @@
 from __future__ import absolute_import
 
 from .client import KafkaClient
-from .kafkacodec import (
-    create_message, create_message_set,
-    CODEC_NONE, CODEC_GZIP, CODEC_SNAPPY,
+from .common import (
+    CODEC_GZIP, CODEC_LZ4, CODEC_NONE, CODEC_SNAPPY,
+    OFFSET_COMMITTED, OFFSET_EARLIEST, OFFSET_LATEST,
 )
-from .producer import Producer
-from .partitioner import RoundRobinPartitioner, HashedPartitioner
 from .consumer import Consumer
-from .common import (OFFSET_EARLIEST, OFFSET_LATEST, OFFSET_COMMITTED,)
+from .kafkacodec import create_message, create_message_set
+from .partitioner import HashedPartitioner, RoundRobinPartitioner
+from .producer import Producer
 
 # Note, you need to bump the version in setup.py as well
 __title__ = 'afkak'
@@ -25,6 +25,6 @@ __all__ = [
     'KafkaClient', 'Producer', 'Consumer',
     'RoundRobinPartitioner', 'HashedPartitioner',
     'create_message', 'create_message_set',
-    'CODEC_NONE', 'CODEC_GZIP', 'CODEC_SNAPPY',
+    'CODEC_NONE', 'CODEC_GZIP', 'CODEC_LZ4', 'CODEC_SNAPPY',
     'OFFSET_EARLIEST', 'OFFSET_LATEST', 'OFFSET_COMMITTED',
 ]

--- a/afkak/kafkacodec.py
+++ b/afkak/kafkacodec.py
@@ -17,21 +17,19 @@ from ._util import (
 )
 from .codec import gzip_decode, gzip_encode, snappy_decode, snappy_encode
 from .common import (
-    BrokerMetadata, BufferUnderflowError, ChecksumError,
-    ConsumerFetchSizeTooSmall, ConsumerMetadataResponse, FetchResponse,
-    InvalidMessageError, Message, OffsetAndMessage, OffsetCommitResponse,
-    OffsetFetchResponse, OffsetResponse, PartitionMetadata, ProduceResponse,
-    ProtocolError, TopicMetadata, UnsupportedCodecError,
+    CODEC_GZIP, CODEC_NONE, CODEC_SNAPPY, BrokerMetadata, BufferUnderflowError,
+    ChecksumError, ConsumerFetchSizeTooSmall, ConsumerMetadataResponse,
+    FetchResponse, InvalidMessageError, Message, OffsetAndMessage,
+    OffsetCommitResponse, OffsetFetchResponse, OffsetResponse,
+    PartitionMetadata, ProduceResponse, ProtocolError, TopicMetadata,
+    UnsupportedCodecError,
 )
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
+_SUPPORTED_CODECS = (CODEC_GZIP, CODEC_NONE, CODEC_SNAPPY)
 ATTRIBUTE_CODEC_MASK = 0x03
-CODEC_NONE = 0x00
-CODEC_GZIP = 0x01
-CODEC_SNAPPY = 0x02
-ALL_CODECS = (CODEC_NONE, CODEC_GZIP, CODEC_SNAPPY)
 MAX_BROKERS = 1024
 
 # Default number of msecs the lead-broker will wait for replics to
@@ -605,9 +603,7 @@ def create_gzip_message(message_set):
     encoded_message_set = KafkaCodec._encode_message_set(message_set)
 
     gzipped = gzip_encode(encoded_message_set)
-    codec = ATTRIBUTE_CODEC_MASK & CODEC_GZIP
-
-    return Message(0, 0x00 | codec, None, gzipped)
+    return Message(0, CODEC_GZIP, None, gzipped)
 
 
 def create_snappy_message(message_set):
@@ -620,11 +616,8 @@ def create_snappy_message(message_set):
     :param list message_set: a list of :class:`Message` instances
     """
     encoded_message_set = KafkaCodec._encode_message_set(message_set)
-
     snapped = snappy_encode(encoded_message_set)
-    codec = ATTRIBUTE_CODEC_MASK & CODEC_SNAPPY
-
-    return Message(0, 0x00 | codec, None, snapped)
+    return Message(0, CODEC_SNAPPY, None, snapped)
 
 
 def create_message_set(requests, codec=CODEC_NONE):
@@ -638,9 +631,9 @@ def create_message_set(requests, codec=CODEC_NONE):
     :param codec:
         The encoding for the message set, one of the constants:
 
-          * :const:`CODEC_NONE`
-          * :const:`CODEC_GZIP`
-          * :const:`CODEC_SNAPPY`
+          * :const:`afkak.CODEC_NONE`
+          * :const:`afkak.CODEC_GZIP`
+          * :const:`afkak.CODEC_SNAPPY`
 
     :raises: :exc:`UnsupportedCodecError` for an unsupported codec
     """

--- a/afkak/producer.py
+++ b/afkak/producer.py
@@ -5,29 +5,25 @@
 from __future__ import absolute_import
 
 import logging
-
-from numbers import Integral
 from collections import defaultdict
+from numbers import Integral
 
-from twisted.python.failure import Failure
+from twisted.internet.defer import CancelledError as tid_CancelledError
 from twisted.internet.defer import (
-    Deferred, DeferredList, inlineCallbacks, returnValue, fail,
-    CancelledError as tid_CancelledError,
-    )
+    Deferred, DeferredList, fail, inlineCallbacks, returnValue,
+)
 from twisted.internet.task import LoopingCall
+from twisted.python.failure import Failure
 
-from .common import (
-    ProduceRequest, UnsupportedCodecError, NoResponseError,
-    SendRequest, TopicAndPartition, CancelledError,
-    FailedPayloadsError, KafkaError,
-    UnknownTopicOrPartitionError, NotLeaderForPartitionError,
-    _check_error,
-    PRODUCER_ACK_LOCAL_WRITE,
-    PRODUCER_ACK_NOT_REQUIRED,
-    )
 from ._util import _coerce_topic
-from .partitioner import (RoundRobinPartitioner)
-from .kafkacodec import CODEC_NONE, ALL_CODECS, create_message_set
+from .common import (
+    CODEC_NONE, PRODUCER_ACK_LOCAL_WRITE, PRODUCER_ACK_NOT_REQUIRED,
+    CancelledError, FailedPayloadsError, KafkaError, NoResponseError,
+    NotLeaderForPartitionError, ProduceRequest, SendRequest, TopicAndPartition,
+    UnknownTopicOrPartitionError, UnsupportedCodecError, _check_error,
+)
+from .kafkacodec import _SUPPORTED_CODECS, create_message_set
+from .partitioner import RoundRobinPartitioner
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -145,7 +141,7 @@ class Producer(object):
         # Are we compressing messages, or just sending 'raw'?
         if codec is None:
             codec = CODEC_NONE
-        elif codec not in ALL_CODECS:
+        elif codec not in _SUPPORTED_CODECS:
             if not isinstance(codec, Integral):
                 raise TypeError("Codec: %r unsupported" % codec)
             raise UnsupportedCodecError("Codec 0x%02x unsupported" % codec)


### PR DESCRIPTION
I grow weary of megabytes-long lines of output when the tests fail.