### PR TITLE
tox.ini: Don't pass through TEAMCITY_VERSION

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ passenv =
     KAFKA_VERSION
     CPPFLAGS
     LANG
-    TEAMCITY_VERSION
     TRAVIS
 
 extras =


### PR DESCRIPTION
This is an obsolete artifact of internal build systems.