### PR TITLE
Group unit and lint builds together

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@
       },
       {
         "env": "TOXENV=py35-unit,py35-unit-snappy-murmur",
-        "name": "Unit and Lint: py35",
+        "name": "Unit: py35",
         "python": "3.5"
       },
       {
@@ -73,7 +73,7 @@
       },
       {
         "env": "TOXENV=py36-unit,py36-unit-snappy-murmur",
-        "name": "Unit and Lint: py36",
+        "name": "Unit: py36",
         "python": "3.6"
       },
       {
@@ -84,7 +84,7 @@
       {
         "dist": "trusty",
         "env": "TOXENV=pypy-unit,pypy-unit-snappy",
-        "name": "Unit and Lint: pypy",
+        "name": "Unit: pypy",
         "python": "pypy"
       }
     ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,11 @@
     "include": [
       {
         "env": "TOXENV=docs",
+        "name": "Documentation",
         "python": "2.7"
       },
       {
+        "name": "Self-check",
         "python": "3.5",
         "script": [
           "tox -l | tools/gentravis.py > .travis.yml",
@@ -38,50 +40,51 @@
       {
         "env": "TOXENV=py27-int-snappy-murmur KAFKA_VERSION=0.9.0.1",
         "jdk": "openjdk8",
+        "name": "Integration: py27 + Kafka 0.9.0.1",
         "python": "2.7"
       },
       {
         "env": "TOXENV=py27-int-snappy-murmur KAFKA_VERSION=1.1.1",
         "jdk": "openjdk8",
+        "name": "Integration: py27 + Kafka 1.1.1",
         "python": "2.7"
       },
       {
-        "env": "TOXENV=py27-lint",
-        "python": "2.7"
-      },
-      {
-        "env": "TOXENV=py27-unit,py27-unit-snappy-murmur",
+        "env": "TOXENV=py27-lint,py27-unit,py27-unit-snappy-murmur",
+        "name": "Unit and Lint: py27",
         "python": "2.7"
       },
       {
         "env": "TOXENV=py35-unit,py35-unit-snappy-murmur",
+        "name": "Unit and Lint: py35",
         "python": "3.5"
       },
       {
         "env": "TOXENV=py36-int-snappy-murmur KAFKA_VERSION=0.9.0.1",
         "jdk": "openjdk8",
+        "name": "Integration: py36 + Kafka 0.9.0.1",
         "python": "3.6"
       },
       {
         "env": "TOXENV=py36-int-snappy-murmur KAFKA_VERSION=1.1.1",
         "jdk": "openjdk8",
+        "name": "Integration: py36 + Kafka 1.1.1",
         "python": "3.6"
       },
       {
         "env": "TOXENV=py36-unit,py36-unit-snappy-murmur",
+        "name": "Unit and Lint: py36",
         "python": "3.6"
       },
       {
-        "env": "TOXENV=py37-lint",
-        "python": "3.7"
-      },
-      {
-        "env": "TOXENV=py37-unit,py37-unit-snappy-murmur",
+        "env": "TOXENV=py37-lint,py37-unit,py37-unit-snappy-murmur",
+        "name": "Unit and Lint: py37",
         "python": "3.7"
       },
       {
         "dist": "trusty",
         "env": "TOXENV=pypy-unit,pypy-unit-snappy",
+        "name": "Unit and Lint: pypy",
         "python": "pypy"
       }
     ]

--- a/tools/gentravis.py
+++ b/tools/gentravis.py
@@ -67,6 +67,7 @@ matrix_include = [{
     ],
 }]
 
+
 def group_envs(envlist):
     """Group Tox environments for Travis CI builds
 
@@ -98,8 +99,12 @@ def group_envs(envlist):
 for envpy, category, envs in group_envs(envlist):
     toxenv = ','.join(envs)
     if category == 'unit':
+        if any(env.endswith('-lint') for env in envs):
+            name = "Unit and Lint: {}".format(envpy)
+        else:
+            name = "Unit: {}".format(envpy)
         matrix_include.append({
-            'name': "Unit and Lint: {}".format(envpy),
+            'name': name,
             'env': 'TOXENV={}'.format(toxenv),
             **envpy_to_travis[envpy],
         })


### PR DESCRIPTION
Use the same Travis CI job for unit and lint when the Python version matches. This amortizes Travis startup time across more useful work.