### PR TITLE
Linting

### DIFF
--- a/afkak/brokerclient.py
+++ b/afkak/brokerclient.py
@@ -319,13 +319,15 @@ class _KafkaBrokerClient(ClientFactory):
     # FIXME: This should not be a public API. The Deferred returned by
     # makeRequest already has a cancel() method.
     # XXX: Wat is the fourth argument I don't even?!
-    def cancelRequest(self, requestId, reason=CancelledError(), _=None):
+    def cancelRequest(self, requestId, reason=None, _=None):
         """Cancel a request: remove it from requests, & errback the deferred.
 
         NOTE: Attempts to cancel a request which is no longer tracked
           (expectResponse == False and already sent, or response already
           received) will raise KeyError
         """
+        if reason is None:
+            reason = CancelledError()
         tReq = self.requests.pop(requestId)
         tReq.d.errback(reason)
 

--- a/afkak/client.py
+++ b/afkak/client.py
@@ -51,6 +51,9 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
+_DEFAULT_RETRY_POLICY = backoffPolicy()
+
+
 class KafkaClient(object):
     """Cluster-aware Kafka client
 
@@ -164,7 +167,7 @@ class KafkaClient(object):
                  correlation_id=0,
                  reactor=None,
                  endpoint_factory=HostnameEndpoint,
-                 retry_policy=backoffPolicy()):
+                 retry_policy=_DEFAULT_RETRY_POLICY):
         self.timeout = float(timeout) / 1000.0  # msecs to secs
 
         if clientId is not None:

--- a/afkak/kafkacodec.py
+++ b/afkak/kafkacodec.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2015 Cyan, Inc.
-# Copyright 2017, 2018 Ciena Corporation
+# Copyright 2017, 2018, 2019 Ciena Corporation
 
 from __future__ import absolute_import
 
@@ -255,10 +255,10 @@ class KafkaCodec(object):
         """
         ((correlation_id, num_topics), cur) = relative_unpack('>ii', data, 0)
 
-        for i in range(num_topics):
+        for _i in range(num_topics):
             topic, cur = read_short_ascii(data, cur)
             ((num_partitions,), cur) = relative_unpack('>i', data, cur)
-            for i in range(num_partitions):
+            for _i in range(num_partitions):
                 ((partition, error, offset), cur) = relative_unpack('>ihq', data, cur)
 
                 yield ProduceResponse(topic, partition, error, offset)
@@ -307,11 +307,11 @@ class KafkaCodec(object):
         """
         ((correlation_id, num_topics), cur) = relative_unpack('>ii', data, 0)
 
-        for i in range(num_topics):
+        for _i in range(num_topics):
             (topic, cur) = read_short_ascii(data, cur)
             ((num_partitions,), cur) = relative_unpack('>i', data, cur)
 
-            for i in range(num_partitions):
+            for _i in range(num_partitions):
                 ((partition, error, highwater_mark_offset), cur) = \
                     relative_unpack('>ihq', data, cur)
 
@@ -352,16 +352,16 @@ class KafkaCodec(object):
         """
         ((correlation_id, num_topics), cur) = relative_unpack('>ii', data, 0)
 
-        for i in range(num_topics):
+        for _i in range(num_topics):
             (topic, cur) = read_short_ascii(data, cur)
             ((num_partitions,), cur) = relative_unpack('>i', data, cur)
 
-            for i in range(num_partitions):
-                ((partition, error, num_offsets,), cur) = \
+            for _i in range(num_partitions):
+                ((partition, error, num_offsets), cur) = \
                     relative_unpack('>ihi', data, cur)
 
                 offsets = []
-                for j in range(num_offsets):
+                for _i in range(num_offsets):
                     ((offset,), cur) = relative_unpack('>q', data, cur)
                     offsets.append(offset)
 
@@ -403,7 +403,7 @@ class KafkaCodec(object):
 
         # Broker info
         brokers = {}
-        for i in range(numbrokers):
+        for _i in range(numbrokers):
             ((nodeId, ), cur) = relative_unpack('>i', data, cur)
             (host, cur) = read_short_ascii(data, cur)
             ((port,), cur) = relative_unpack('>i', data, cur)
@@ -413,13 +413,13 @@ class KafkaCodec(object):
         ((num_topics,), cur) = relative_unpack('>i', data, cur)
         topic_metadata = {}
 
-        for i in range(num_topics):
+        for _i in range(num_topics):
             ((topic_error,), cur) = relative_unpack('>h', data, cur)
             (topic_name, cur) = read_short_ascii(data, cur)
             ((num_partitions,), cur) = relative_unpack('>i', data, cur)
             partition_metadata = {}
 
-            for j in range(num_partitions):
+            for _j in range(num_partitions):
                 ((partition_error_code, partition, leader, numReplicas),
                  cur) = relative_unpack('>hiii', data, cur)
 
@@ -516,11 +516,11 @@ class KafkaCodec(object):
         ((correlation_id,), cur) = relative_unpack('>i', data, 0)
         ((num_topics,), cur) = relative_unpack('>i', data, cur)
 
-        for i in range(num_topics):
+        for _i in range(num_topics):
             (topic, cur) = read_short_ascii(data, cur)
             ((num_partitions,), cur) = relative_unpack('>i', data, cur)
 
-            for i in range(num_partitions):
+            for _i in range(num_partitions):
                 ((partition, error), cur) = relative_unpack('>ih', data, cur)
                 yield OffsetCommitResponse(topic, partition, error)
 
@@ -547,7 +547,7 @@ class KafkaCodec(object):
             message += write_short_ascii(topic)
             message += struct.pack('>i', len(topic_payloads))
 
-            for partition, payload in topic_payloads.items():
+            for partition in topic_payloads:
                 message += struct.pack('>i', partition)
 
         return message
@@ -563,11 +563,11 @@ class KafkaCodec(object):
         ((correlation_id,), cur) = relative_unpack('>i', data, 0)
         ((num_topics,), cur) = relative_unpack('>i', data, cur)
 
-        for i in range(num_topics):
+        for _i in range(num_topics):
             (topic, cur) = read_short_ascii(data, cur)
             ((num_partitions,), cur) = relative_unpack('>i', data, cur)
 
-            for i in range(num_partitions):
+            for _i in range(num_partitions):
                 ((partition, offset), cur) = relative_unpack('>iq', data, cur)
                 (metadata, cur) = read_short_bytes(data, cur)
                 ((error,), cur) = relative_unpack('>h', data, cur)

--- a/afkak/partitioner.py
+++ b/afkak/partitioner.py
@@ -1,11 +1,22 @@
 # -*- coding: utf-8 -*-
 # Copyright 2015 Cyan, Inc.
-# Copyright 2017, 2018 Ciena Corporation
-import warnings
+# Copyright 2017, 2018, 2019 Ciena Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+import warnings
 from itertools import cycle
 from random import randint
-
 
 try:
     from pyhash import murmur2_32 as _murmur2_32

--- a/afkak/producer.py
+++ b/afkak/producer.py
@@ -161,7 +161,7 @@ class Producer(object):
                                                self.batchDesc, self.req_acks,
                                                self.ack_timeout)
 
-    def send_messages(self, topic, key=None, msgs=[]):
+    def send_messages(self, topic, key=None, msgs=()):
         """
         Given a topic, and optional key (for partitioning) and a list of
         messages, send them to Kafka, either immediately, or when a batch is
@@ -394,12 +394,11 @@ class Producer(object):
         Since this can be called from the callback chain, we
         pass through our first (non-self) arg
         """
-        if ((self.batch_every_n and
-             self.batch_every_n <= self._waitingMsgCount
-             ) or (
-             self.batch_every_b and
-             self.batch_every_b <= self._waitingByteCount)):
-                self._send_batch()
+        if (
+            (self.batch_every_n and self.batch_every_n <= self._waitingMsgCount) or
+            (self.batch_every_b and self.batch_every_b <= self._waitingByteCount)
+           ):
+            self._send_batch()
         return result
 
     def _send_batch(self):

--- a/afkak/test/test_client_integration.py
+++ b/afkak/test/test_client_integration.py
@@ -1,16 +1,31 @@
 # -*- coding: utf-8 -*-
 # Copyright 2015 Cyan, Inc.
-# Copyright 2018 Ciena Corporation
+# Copyright 2018, 2019 Ciena Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import logging
 import random
 
-from afkak import KafkaClient
-from afkak.common import (FetchRequest, OffsetCommitRequest,
-                          OffsetFetchRequest, OffsetRequest, ProduceRequest)
-from afkak.kafkacodec import create_message
 from nose.twistedtools import deferred, threaded_reactor
 from twisted.internet.defer import inlineCallbacks
+
+from afkak import KafkaClient
+from afkak.common import (
+    FetchRequest, OffsetCommitRequest, OffsetFetchRequest, OffsetRequest,
+    ProduceRequest,
+)
+from afkak.kafkacodec import create_message
 
 from .fixtures import KafkaHarness
 from .testutil import KafkaIntegrationTestCase, kafka_versions, random_string

--- a/afkak/test/test_codec.py
+++ b/afkak/test/test_codec.py
@@ -1,6 +1,18 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2015 Cyan, Inc.
-# Copyright 2018 Ciena Corporation
+# Copyright 2018, 2019 Ciena Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import os
 import struct
@@ -11,22 +23,22 @@ from six.moves import reload_module
 
 import afkak
 from afkak.codec import (
-    has_gzip, has_snappy, gzip_encode, gzip_decode,
-    snappy_encode, snappy_decode
+    gzip_decode, gzip_encode, has_gzip, has_snappy, snappy_decode,
+    snappy_encode,
 )
 
 
 class TestCodec(unittest.TestCase):
     @unittest.skipUnless(has_gzip(), "Gzip not available")
     def test_gzip(self):
-        for i in range(100):
+        for _i in range(100):
             s1 = os.urandom(100)
             s2 = gzip_decode(gzip_encode(s1))
             self.assertEqual(s1, s2)
 
     @unittest.skipUnless(has_snappy(), "Snappy not available")
     def test_snappy(self):
-        for i in range(100):
+        for _i in range(100):
             s1 = os.urandom(120)
             s2 = snappy_decode(snappy_encode(s1))
             self.assertEqual(s1, s2)

--- a/afkak/test/test_consumer.py
+++ b/afkak/test/test_consumer.py
@@ -1,6 +1,18 @@
 # -*- coding: utf-8 -*-
 # Copyright 2015 Cyan, Inc.
-# Copyright 2017, 2018 Ciena Corporation
+# Copyright 2017, 2018, 2019 Ciena Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import logging
 
@@ -11,15 +23,15 @@ from twisted.test.proto_helpers import MemoryReactorClock
 from twisted.trial import unittest
 
 from .. import consumer as kconsumer  # for patching
-from ..common import (KAFKA_SUCCESS, OFFSET_COMMITTED, OFFSET_EARLIEST,
-                      OFFSET_LATEST, TIMESTAMP_INVALID,
-                      ConsumerFetchSizeTooSmall, FetchRequest, FetchResponse,
-                      InvalidConsumerGroupError, KafkaUnavailableError,
-                      Message, OffsetCommitRequest, OffsetCommitResponse,
-                      OffsetFetchRequest, OffsetFetchResponse,
-                      OffsetOutOfRangeError, OffsetRequest, OffsetResponse,
-                      OperationInProgress, RestartError, RestopError, UnknownError,
-                      SourcedMessage)
+from ..common import (
+    KAFKA_SUCCESS, OFFSET_COMMITTED, OFFSET_EARLIEST, OFFSET_LATEST,
+    TIMESTAMP_INVALID, ConsumerFetchSizeTooSmall, FetchRequest, FetchResponse,
+    InvalidConsumerGroupError, KafkaUnavailableError, Message,
+    OffsetCommitRequest, OffsetCommitResponse, OffsetFetchRequest,
+    OffsetFetchResponse, OffsetOutOfRangeError, OffsetRequest, OffsetResponse,
+    OperationInProgress, RestartError, RestopError, SourcedMessage,
+    UnknownError,
+)
 from ..consumer import FETCH_BUFFER_SIZE_BYTES, Consumer
 from ..kafkacodec import KafkaCodec, create_message
 
@@ -84,7 +96,7 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             Consumer(
                 Mock(), 'topic', 0, Mock(),
                 consumer_group='test_consumer_non_str_auto_offset_reset',
-                auto_offset_reset=111
+                auto_offset_reset=111,
             )
 
     def test_consumer_str_not_expected(self):
@@ -92,7 +104,7 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             Consumer(
                 Mock(), 'topic', 0, Mock(),
                 consumer_group='test_consumer_str_not_expected',
-                auto_offset_reset="not_expected"
+                auto_offset_reset="not_expected",
             )
 
     def test_consumer_init(self):
@@ -154,7 +166,7 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         offset = 2346  # arbitrary
         topic = 'latestTopic'
         part = 10
-        reqs_ds = [Deferred(), Deferred(), ]
+        reqs_ds = [Deferred(), Deferred()]
         clock = MemoryReactorClock()
         mockclient = Mock(reactor=clock)
         mockclient.send_offset_request.return_value = reqs_ds[0]
@@ -182,7 +194,7 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         fetch_offset = offset + 1  # fetch at next offset after committed
         topic = u'committedTopic'
         part = 23
-        reqs_ds = [Deferred(), Deferred(), ]
+        reqs_ds = [Deferred(), Deferred()]
         clock = MemoryReactorClock()
         mockclient = Mock(reactor=clock)
         mockclient.send_offset_fetch_request.return_value = reqs_ds[0]
@@ -315,7 +327,7 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             the_group, [the_request])
         # 'Send' the commit response
         commit_response = [
-            OffsetCommitResponse(the_topic, the_part, KAFKA_SUCCESS)
+            OffsetCommitResponse(the_topic, the_part, KAFKA_SUCCESS),
         ]
         client_requests[1].callback(commit_response)
 
@@ -633,7 +645,7 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         # create & deliver the response
         messages = [
             create_message(b"v9", b"k9"),
-            create_message(b"v10", b"k10")
+            create_message(b"v10", b"k10"),
         ]
         message_set = KafkaCodec._encode_message_set(messages, offset)
         message_iter = KafkaCodec._decode_message_set_iter(message_set)
@@ -746,7 +758,7 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         # create & deliver the response
         messages = [
             create_message(b"v1", b"k1"),
-            create_message(b"v2", b"k2")
+            create_message(b"v2", b"k2"),
         ]
         message_set = KafkaCodec._encode_message_set(messages, offset)
         message_iter = KafkaCodec._decode_message_set_iter(message_set)
@@ -1406,7 +1418,7 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         # create & deliver the response
         messages = [
             create_message(b"v1", b"k1"),
-            create_message(b"v2", b"k2")
+            create_message(b"v2", b"k2"),
         ]
         message_set = KafkaCodec._encode_message_set(messages, offset)
         message_iter = KafkaCodec._decode_message_set_iter(message_set)

--- a/afkak/test/test_kafkacodec.py
+++ b/afkak/test/test_kafkacodec.py
@@ -1,39 +1,49 @@
 # -*- coding: utf-8 -*-
 # Copyright 2015 Cyan, Inc.
 # Copyright 2017, 2018, 2019 Ciena Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
-Test code for KafkaCodec(object) class.
+Test the KafkaCodec class.
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
-from contextlib import contextmanager
 import struct
-from unittest import TestCase, SkipTest
+from contextlib import contextmanager
+from unittest import SkipTest, TestCase
 
-import six
 import mock
+import six
 from mock import sentinel
 
-from afkak.common import (
-    OffsetRequest, OffsetCommitRequest, OffsetFetchRequest,
-    OffsetResponse, OffsetCommitResponse, OffsetFetchResponse,
-    ProduceRequest, FetchRequest, Message, ChecksumError,
-    ConsumerFetchSizeTooSmall, ProduceResponse, FetchResponse,
-    OffsetAndMessage, BrokerMetadata, PartitionMetadata, TopicMetadata,
-    ProtocolError, UnsupportedCodecError, InvalidMessageError,
-    ConsumerMetadataResponse,
-)
-from afkak.codec import (
-    has_snappy, gzip_decode, snappy_decode
-)
 import afkak.kafkacodec
-from afkak.kafkacodec import (
-    ATTRIBUTE_CODEC_MASK, CODEC_NONE, CODEC_GZIP, CODEC_SNAPPY,
-    create_message, create_gzip_message, create_snappy_message,
-    create_message_set, KafkaCodec
+from afkak.codec import gzip_decode, has_snappy, snappy_decode
+from afkak.common import (
+    BrokerMetadata, ChecksumError, ConsumerFetchSizeTooSmall,
+    ConsumerMetadataResponse, FetchRequest, FetchResponse, InvalidMessageError,
+    Message, OffsetAndMessage, OffsetCommitRequest, OffsetCommitResponse,
+    OffsetFetchRequest, OffsetFetchResponse, OffsetRequest, OffsetResponse,
+    PartitionMetadata, ProduceRequest, ProduceResponse, ProtocolError,
+    TopicMetadata, UnsupportedCodecError,
 )
+from afkak.kafkacodec import (
+    ATTRIBUTE_CODEC_MASK, CODEC_GZIP, CODEC_NONE, CODEC_SNAPPY, KafkaCodec,
+    create_gzip_message, create_message, create_message_set,
+    create_snappy_message,
+)
+
 from .testutil import make_send_requests
 
 
@@ -186,7 +196,7 @@ class TestKafkaCodec(TestCase):
     def test_encode_message_set(self):
         message_set = [
             create_message(b"v1", b"k1"),
-            create_message(b"v2", b"k2")
+            create_message(b"v2", b"k2"),
         ]
 
         encoded = KafkaCodec._encode_message_set(message_set)
@@ -347,11 +357,11 @@ class TestKafkaCodec(TestCase):
         requests = [
             ProduceRequest("topic1", 0, [
                 create_message(b"a"),
-                create_message(b"b")
+                create_message(b"b"),
             ]),
             ProduceRequest(u"topic2", 1, [
-                create_message(b"c")
-            ])
+                create_message(b"c"),
+            ]),
         ]
 
         msg_a_binary = KafkaCodec._encode_message(create_message(b"a"))
@@ -512,20 +522,20 @@ class TestKafkaCodec(TestCase):
         node_brokers = {
             0: BrokerMetadata(0, "brokers1.afkak.rdio.com", 1000),
             1: BrokerMetadata(1, "brokers1.afkak.rdio.com", 1001),
-            3: BrokerMetadata(3, "brokers2.afkak.rdio.com", 1000)
+            3: BrokerMetadata(3, "brokers2.afkak.rdio.com", 1000),
         }
 
         topic_partitions = {
             "topic1": TopicMetadata(
                 'topic1', 0, {
                     0: PartitionMetadata(u"topic1", 0, 0, 1, (0, 2), (2,)),
-                    1: PartitionMetadata("topic1", 1, 1, 3, (0, 1), (0, 1))
-                }
+                    1: PartitionMetadata("topic1", 1, 1, 3, (0, 1), (0, 1)),
+                },
             ),
             u"topic2": TopicMetadata(
                 u'topic2', 1, {
-                    0: PartitionMetadata(u"topic2", 0, 0, 0, (), ())
-                }
+                    0: PartitionMetadata(u"topic2", 0, 0, 0, (), ()),
+                },
             ),
         }
         encoded = create_encoded_metadata_response(

--- a/afkak/test/test_kafkacodec.py
+++ b/afkak/test/test_kafkacodec.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2015 Cyan, Inc.
-# Copyright 2017, 2018 Ciena Corporation.
+# Copyright 2017, 2018, 2019 Ciena Corporation.
 
 """
 Test code for KafkaCodec(object) class.

--- a/afkak/test/test_partitioner.py
+++ b/afkak/test/test_partitioner.py
@@ -1,23 +1,35 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2015 Cyan, Inc.
+# Copyright 2015 Cyan, Inc.
+# Copyright 2019 Ciena Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Test code for Partitioner(object), RoundRobinPartitioner(object),
 and HashedPartitioner(object) classes.
 """
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import logging
 from collections import defaultdict
-
 from math import sqrt
-
 from unittest import TestCase
+
+from afkak.partitioner import (
+    HashedPartitioner, Partitioner, RoundRobinPartitioner, pure_murmur2,
+)
+
 from .testutil import random_string
-
-from afkak.partitioner import (Partitioner, RoundRobinPartitioner,
-                               HashedPartitioner, pure_murmur2)
-
 
 log = logging.getLogger(__name__)
 
@@ -84,7 +96,7 @@ class TestRoundRobinPartitioner(TestCase):
         # Try a number of times and check the distribution of the start
         firstParts = defaultdict(lambda: 0)
         trycount = 10000
-        for i in range(trycount):
+        for _i in range(trycount):
             p1 = RoundRobinPartitioner(None, parts)
             firstParts[p1.partition(None, parts)] += 1
 
@@ -189,7 +201,7 @@ class TestHashedPartitioner(TestCase):
         key_list = []
         part_keycount = defaultdict(lambda: 0)
         key_to_part = {}
-        for i in range(keycount):
+        for _i in range(keycount):
             key = random_string(16)
             key_list.append(key)
             part = p.partition(key, parts)

--- a/afkak/test/test_producer.py
+++ b/afkak/test/test_producer.py
@@ -1,12 +1,24 @@
 # -*- coding: utf-8 -*-
 # Copyright 2015 Cyan, Inc.
-# Copyright 2018 Ciena Corporation
+# Copyright 2018, 2019 Ciena Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import logging
 import uuid
 
-from mock import ANY, Mock, call, patch
 import six
+from mock import ANY, Mock, call, patch
 from twisted.internet.defer import CancelledError as tid_CancelledError
 from twisted.internet.defer import Deferred, fail, succeed
 from twisted.internet.task import LoopingCall
@@ -15,12 +27,12 @@ from twisted.test.proto_helpers import MemoryReactorClock
 from twisted.trial import unittest
 
 from .. import producer as aProducer
-from ..common import (PRODUCER_ACK_NOT_REQUIRED, BrokerNotAvailableError,
-                      CancelledError, FailedPayloadsError,
-                      LeaderNotAvailableError, NoResponseError,
-                      NotLeaderForPartitionError, OffsetOutOfRangeError,
-                      ProduceRequest, ProduceResponse,
-                      UnknownTopicOrPartitionError, UnsupportedCodecError)
+from ..common import (
+    PRODUCER_ACK_NOT_REQUIRED, BrokerNotAvailableError, CancelledError,
+    FailedPayloadsError, LeaderNotAvailableError, NoResponseError,
+    NotLeaderForPartitionError, OffsetOutOfRangeError, ProduceRequest,
+    ProduceResponse, UnknownTopicOrPartitionError, UnsupportedCodecError,
+)
 from ..kafkacodec import create_message_set
 from ..producer import Producer
 from .testutil import make_send_requests, random_string

--- a/afkak/test/test_producer_integration.py
+++ b/afkak/test/test_producer_integration.py
@@ -6,19 +6,25 @@ import logging
 import time
 from unittest import skipUnless
 
-from afkak import (CODEC_GZIP, CODEC_SNAPPY, HashedPartitioner, Producer,
-                   RoundRobinPartitioner, create_message, create_message_set)
-from afkak.codec import has_snappy
-from afkak.common import (PRODUCER_ACK_ALL_REPLICAS, PRODUCER_ACK_LOCAL_WRITE,
-                          PRODUCER_ACK_NOT_REQUIRED, FetchRequest,
-                          ProduceRequest, SendRequest)
 from nose.twistedtools import deferred, threaded_reactor
 from twisted.internet.defer import inlineCallbacks
 from twisted.trial import unittest
 
+from afkak import (
+    CODEC_GZIP, CODEC_SNAPPY, HashedPartitioner, Producer,
+    RoundRobinPartitioner, create_message, create_message_set,
+)
+from afkak.codec import has_snappy
+from afkak.common import (
+    PRODUCER_ACK_ALL_REPLICAS, PRODUCER_ACK_LOCAL_WRITE,
+    PRODUCER_ACK_NOT_REQUIRED, FetchRequest, ProduceRequest, SendRequest,
+)
+
 from .fixtures import KafkaHarness
-from .testutil import (KafkaIntegrationTestCase, async_delay, kafka_versions,
-                       make_send_requests, random_string)
+from .testutil import (
+    KafkaIntegrationTestCase, async_delay, kafka_versions, make_send_requests,
+    random_string,
+)
 
 log = logging.getLogger(__name__)
 
@@ -166,9 +172,7 @@ class TestAfkakProducerIntegration(KafkaIntegrationTestCase, unittest.TestCase):
         msg_count = 1+100
         messages = [
             create_message(b"Just a plain message"),
-            create_message_set(
-                make_send_requests(
-                    [b"Gzipped %d" % i for i in range(100)]), CODEC_GZIP)[0]
+            create_message_set(make_send_requests([b"Gzipped %d" % i for i in range(100)]), CODEC_GZIP)[0],
         ]
 
         # Can't produce snappy messages without snappy...
@@ -663,7 +667,7 @@ class TestAfkakProducerIntegration(KafkaIntegrationTestCase, unittest.TestCase):
 
     @inlineCallbacks
     def assert_fetch_offset(self, partition, start_offset,
-                            expected_messages, expected_keys=[],
+                            expected_messages, expected_keys=(),
                             max_wait=0.5, fetch_size=1024, topic=None):
         # There should only be one response message from the server.
         # This will throw an exception if there's more than one.

--- a/tox.ini
+++ b/tox.ini
@@ -29,9 +29,8 @@ deps =
     nose-timer==0.5.0
     Twisted==18.9.0
     lint: flake8
-    ; TODO Enable flake8-isort once all files are clean.
-    ; lint: flake8-isort==2.5
-    py37-lint: flake8-bugbear
+    lint: flake8-isort==2.6.0
+    py37-lint: flake8-bugbear==18.8.0
     pylint: pylint
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,8 @@ deps =
     nose-timer==0.5.0
     Twisted==18.9.0
     lint: flake8
-    lint: flake8-isort==2.6.0
+    py37-lint: flake8-isort==2.6.0
+    py37-lint: flake8-commas==2.0.0
     py37-lint: flake8-bugbear==18.8.0
     pylint: pylint
 
@@ -52,6 +53,7 @@ commands =
     int:  --logging-format='%(asctime)s %(levelname)s %(filename)s:%(lineno)d: %(message)s' \
     int:  --ignore-files=^((?!_integration).)*$ {posargs}
 
+    lint: flake8 --version
     lint: flake8 afkak
     pylint: pylint afkak --rcfile={toxinidir}/.pylintrc --output-format={env:PYLINT_OUTPUT_FORMAT:colorized}
 
@@ -127,16 +129,8 @@ enable = E124
 jobs = auto
 
 [isort]
-known_third_party =
-    attr
-    mock
-    murmur
-    nose
-    pyhash
-    six
-    twisted
-    zope
-    __pypy__
+default_section = thirdparty
+known_first_party = afkak
 use_parenthesis = true
 multi_line_output = 5
 include_trailing_comma = true

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ deps =
     lint: flake8
     ; TODO Enable flake8-isort once all files are clean.
     ; lint: flake8-isort==2.5
+    py37-lint: flake8-bugbear
     pylint: pylint
 
 commands =


### PR DESCRIPTION
Add a few linting tools:

* [flake8-bugbear](https://pypi.org/project/flake8-bugbear/) &mdash; this catches some common errors, notably bare `except:`. I haven't enabled its opinionated warnings.
* [flake8-isort](https://pypi.org/project/flake8-isort/) &mdash; sort `import` statements automatically. I've been using `isort` to apply this sorting for a while because it makes it easier to merge long-running branches (when the imports conflict, just take the union and run `isort` to remove duplicates).
* [flake8-commas](https://pypi.org/project/flake8-commas/) &mdash; require trailing commas. This isn't JavaScript on IE6: we can have nice things.

All these new linters are only run on Python 3.7. There isn't any need to run them on the Python 2.7 lint run, which only exists to detect syntax issues.