### PR TITLE
consumer_example use shutdown instead of stop

### DIFF
--- a/consumer_example
+++ b/consumer_example
@@ -71,13 +71,13 @@ def consume(reactor, hosts='localhost:9092'):
     def stop_consumers():
         log.info("\n")
         log.info("Time is up, stopping consumers...")
-        d = defer.gatherResults([c.stop() for c in consumers])
+        d = defer.gatherResults([c.shutdown() for c in consumers])
         d.addCallback(lambda result: client.close())
         return d
 
     yield defer.gatherResults(
-        [c.start(OFFSET_LATEST).addCallbacks(cb_closed, eb_failed) for c in consumers]
-        + [task.deferLater(reactor, 60.0, stop_consumers)]
+        [c.start(OFFSET_LATEST).addCallbacks(cb_closed, eb_failed) for c in consumers] +
+        [task.deferLater(reactor, 60.0, stop_consumers)]
     )
 
 
@@ -88,6 +88,7 @@ def main():
     )
     task.react(consume, sys.argv[1:])
     log.info("All Done!")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
`Consumer.stop()` does not return a `Deferred `and instead it returns the last committed offset (an int), so it currently raises an `AttributeError` when trying to add a callback to the int.

```
afkak.protocol WARNING Lost Connection to Kafka Broker: <twisted.python.failure.Failure twisted.internet.error.ConnectionLost: Connection to the other side was lost in a non-clean fashion: Connection lost.>
Unhandled error in Deferred:

Traceback (most recent call last):
  File "/home/ubuntu/projects/crinoid/env/local/lib/python2.7/site-packages/twisted/internet/base.py", line 1276, in mainLoop
    self.runUntilCurrent()
  File "/home/ubuntu/projects/crinoid/env/local/lib/python2.7/site-packages/twisted/internet/base.py", line 902, in runUntilCurrent
    call.func(*call.args, **call.kw)
  File "/home/ubuntu/projects/crinoid/env/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 460, in callback
    self._startRunCallbacks(result)
  File "/home/ubuntu/projects/crinoid/env/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 568, in _startRunCallbacks
    self._runCallbacks()
--- <exception caught here> ---
  File "/home/ubuntu/projects/crinoid/env/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 654, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/home/ubuntu/projects/crinoid/env/local/lib/python2.7/site-packages/twisted/internet/task.py", line 865, in <lambda>
    d.addCallback(lambda ignored: callable(*args, **kw))
  File "./consumer_example", line 79, in stop_consumers
    d = defer.gatherResults([c.stop() for c in consumers])
  File "/home/ubuntu/projects/crinoid/env/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1181, in gatherResults
    consumeErrors=consumeErrors)
  File "/home/ubuntu/projects/crinoid/env/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1097, in __init__
    deferred.addCallbacks(self._cbDeferred, self._cbDeferred,
exceptions.AttributeError: 'int' object has no attribute 'addCallbacks
```

