### PR TITLE
Improved string representations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Version 3.1.0
 
 * **Backwards incompatible:** `afkak.producer.Producer.sendLooper` and `.sendLooperD` are no longer public symbols.
 
+* Debug log messages have been enhanced to indicate the type of a message.
+
 Version 3.0.0
 =============
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ Version 3.1.0
 
 * Debug log messages have been enhanced to indicate the type of a message.
 
+* The clientId has been removed from the string representation of internal broker objects.
+
 Version 3.0.0
 =============
 

--- a/afkak/__init__.py
+++ b/afkak/__init__.py
@@ -6,8 +6,8 @@ from __future__ import absolute_import
 
 from .client import KafkaClient
 from .common import (
-    CODEC_GZIP, CODEC_LZ4, CODEC_NONE, CODEC_SNAPPY,
-    OFFSET_COMMITTED, OFFSET_EARLIEST, OFFSET_LATEST,
+    CODEC_GZIP, CODEC_LZ4, CODEC_NONE, CODEC_SNAPPY, OFFSET_COMMITTED,
+    OFFSET_EARLIEST, OFFSET_LATEST,
 )
 from .consumer import Consumer
 from .kafkacodec import create_message, create_message_set

--- a/afkak/brokerclient.py
+++ b/afkak/brokerclient.py
@@ -118,13 +118,11 @@ class _KafkaBrokerClient(ClientFactory):
 
     def __repr__(self):
         """return a string representing this KafkaBrokerClient."""
-        return '_KafkaBrokerClient<clientId={} node_id={} {}:{} {}>'.format(
-            self.clientId,
+        return '_KafkaBrokerClient<node_id={} {}:{} {}>'.format(
             self.node_id,
             self.host,
             self.port,
             'connected' if self.connected() else 'unconnected',
-            # TODO: Add transport.getPeer() when connected
         )
 
     def updateMetadata(self, new):

--- a/afkak/test/__init__.py
+++ b/afkak/test/__init__.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import logging
+import os
 
 
 def _twisted_debug():

--- a/afkak/test/test_brokerclient.py
+++ b/afkak/test/test_brokerclient.py
@@ -114,7 +114,7 @@ class BrokerClientTests(SynchronousTestCase):
         and broker metadata.
         """
         self.assertEqual(
-            "_KafkaBrokerClient<clientId=myclient node_id=1 host:1234 unconnected>",
+            "_KafkaBrokerClient<node_id=1 host:1234 unconnected>",
             repr(self.brokerClient),
         )
 
@@ -126,7 +126,7 @@ class BrokerClientTests(SynchronousTestCase):
         self.connections.accept('*')
 
         self.assertEqual(
-            "_KafkaBrokerClient<clientId=myclient node_id=1 host:1234 connected>",
+            "_KafkaBrokerClient<node_id=1 host:1234 connected>",
             repr(self.brokerClient),
         )
 

--- a/afkak/test/test_kafkacodec.py
+++ b/afkak/test/test_kafkacodec.py
@@ -40,7 +40,7 @@ from afkak.common import (
 )
 from afkak.kafkacodec import (
     ATTRIBUTE_CODEC_MASK, CODEC_GZIP, CODEC_NONE, CODEC_SNAPPY, KafkaCodec,
-    create_gzip_message, create_message, create_message_set,
+    _ReprRequest, create_gzip_message, create_message, create_message_set,
     create_snappy_message,
 )
 
@@ -74,6 +74,29 @@ def create_encoded_metadata_response(broker_data, topic_data):
                 encoded += struct.pack('>i', isr)
 
     return encoded
+
+
+class ReprRequestTests(TestCase):
+    def test_produce(self):
+        rr = _ReprRequest((
+            b'\x00\x00'
+            b'\x00\x03'
+            b'\x00\x00\x04\x00'
+            b'xx'
+        ))
+        self.assertEqual('ProduceRequest3 correlationId=1024 (10 bytes)', str(rr))
+
+    def test_unknown_key(self):
+        rr = _ReprRequest((
+            b'\x00\xff'
+            b'\x00\x01'
+            b'\x00\x00\x00\x00'
+        ))
+        self.assertEqual('request key=255v1 correlationId=0 (8 bytes)', str(rr))
+
+    def test_too_short(self):
+        rr = _ReprRequest(b'\x00\x00\xab\xcd')
+        self.assertEqual("invalid request (0000abcd)", str(rr))
 
 
 class TestKafkaCodec(TestCase):


### PR DESCRIPTION
- Display the type, version, and size of requests in _sbur and _mrtb log messages. This makes it easier to infer what is going on.
- Remove clientId from _KafkaBrokerClient's repr. In practice folks either:

    - Don't override clientId
    - Only use a single KafkaClient
    - Use the same clientId for all KafkaClients

  I don't think it's worth the space, particularly when it tends to share a log line with KafkaClient's repr which has the same information.