### PR TITLE
Fix changelog entry location

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Version 3.1.0
+============
+
+* **Backwards incompatible:** `afkak.producer.Producer.sendLooper` and `.sendLooperD` are no longer public symbols.
+
 Version 3.0.0
 =============
 
@@ -105,8 +110,6 @@ This release includes many changes that are technically backwards-incompatible i
     * The `afkak.brokerclient.CLIENT_ID` constant has been removed.
     * `afkak.util` has been renamed `afkak._util`, meaning its contents are no longer part of the public API.
     * `afkak.common.check_error` has been renamed `_check_error`, making it private.
-
-* **Backwards incompatible:** `afkak.producer.Producer.sendLooper` and `.sendLooperD` are no longer public symbols.
 
 Version 2.9.0
 =============


### PR DESCRIPTION
This was not part of 3.0.0, it was merged afterward (#50).