### PR TITLE
Set __consumer_offsets topic partition count to 3

### DIFF
--- a/servers/1.1.1/resources/kafka.properties
+++ b/servers/1.1.1/resources/kafka.properties
@@ -74,6 +74,7 @@ num.recovery.threads.per.data.dir=1
 # The replication factor for the group metadata internal topics "__consumer_offsets" and "__transaction_state"
 # For anything other than development testing, a value greater than 1 is recommended for to ensure availability such as 3.
 offsets.topic.replication.factor={replicas}
+offsets.topic.num.partitions=3
 transaction.state.log.replication.factor={replicas}
 transaction.state.log.min.isr={min_insync_replicas}
 


### PR DESCRIPTION
Auto-creation of this topic takes several seconds at the default of 50 partitions and produces *copious* log output in our integration tests. This should reduce test execution time a bit.