### PR TITLE
reset_topic_metadata() should always clear errors

### DIFF
--- a/afkak/producer.py
+++ b/afkak/producer.py
@@ -290,6 +290,9 @@ class Producer(object):
             # check if we have request attempts left
             if self._req_attempts >= self._max_attempts:
                 # No, no attempts left, so raise the error
+                # FIXME: This can be deceptive. metadata_error_for_topic()
+                # returns the error code for UnknownTopicOrPartitonError when
+                # nothing is known about the topic.
                 _check_error(self.client.metadata_error_for_topic(topic))
             yield self.client.load_metadata_for_topics(topic)
             if not self.client.metadata_error_for_topic(topic):

--- a/afkak/test/test_client.py
+++ b/afkak/test/test_client.py
@@ -88,16 +88,6 @@ def encode_metadata_response(brokers, topics):
     return create_encoded_metadata_response(broker_map, topics)[4:]  # Slice off correlation ID
 
 
-def brkrAndReqsForTopicAndPartition(client, topic, part=0):
-    """
-    Helper function to dig out the outstanding request so we can
-    "send" the response to it. (fire the deferred)
-    """
-    broker = client.topics_to_brokers[TopicAndPartition(topic, part)]
-    brokerClient = client._get_brokerclient(broker.node_id)
-    return (brokerClient, brokerClient.requests)
-
-
 class TestKafkaClient(unittest.TestCase):
     maxDiff = None
 


### PR DESCRIPTION
When a topic is present in `KafkaClient.topic_errors` calling `reset_topic_metadata()` didn't clear it unless it also existed in also exist in `KafkaClient.topic_partitons` — i.e., it had some partitions. This could prevent error state from being cleared, but was probably mostly masked in practice by the aggressive resetting of metadata in other parts of the client.