### PR TITLE
Fix TestAfkakClientIntegration.test_send_offset_request failure

### DIFF
--- a/afkak/test/int/test_client_integration.py
+++ b/afkak/test/int/test_client_integration.py
@@ -127,7 +127,7 @@ class TestAfkakClientIntegration(IntegrationMixin, unittest.TestCase):
     @inlineCallbacks
     def test_send_offset_request(self):
         req = OffsetRequest(self.topic, 0, -1, 100)
-        [resp] = yield self.client.send_offset_request([req])
+        [resp] = yield self.retry_while_broker_errors(self.client.send_offset_request, [req])
         self.assertEqual(resp.error, 0)
         self.assertEqual(resp.topic, self.topic)
         self.assertEqual(resp.partition, 0)


### PR DESCRIPTION
A fix for this failure seen on #37:

    [ERROR]
    Traceback (most recent call last):
      File "/home/travis/build/ciena/afkak/.tox/py27-int-snappy-murmur/lib/python2.7/site-packages/twisted/internet/defer.py", line 1416, in _inlineCallbacks
        result = result.throwExceptionIntoGenerator(g)
      File "/home/travis/build/ciena/afkak/.tox/py27-int-snappy-murmur/lib/python2.7/site-packages/twisted/python/failure.py", line 512, in throwExceptionIntoGenerator
        return g.throw(self.type, self.value, self.tb)
      File "/home/travis/build/ciena/afkak/.tox/py27-int-snappy-murmur/lib/python2.7/site-packages/afkak/test/int/test_client_integration.py", line 130, in test_send_offset_request
        [resp] = yield self.client.send_offset_request([req])
      File "/home/travis/build/ciena/afkak/.tox/py27-int-snappy-murmur/lib/python2.7/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
        result = g.send(result)
      File "/home/travis/build/ciena/afkak/.tox/py27-int-snappy-murmur/lib/python2.7/site-packages/afkak/client.py", line 706, in send_offset_request
        returnValue(self._handle_responses(resps, fail_on_error, callback))
      File "/home/travis/build/ciena/afkak/.tox/py27-int-snappy-murmur/lib/python2.7/site-packages/afkak/client.py", line 763, in _handle_responses
        BrokerResponseError.raise_for_errno(resp.error, resp)
      File "/home/travis/build/ciena/afkak/.tox/py27-int-snappy-murmur/lib/python2.7/site-packages/afkak/common.py", line 311, in raise_for_errno
        raise subcls(*args)
    afkak.common.NotLeaderForPartitionError: error=6 (NOT_LEADER_FOR_PARTITION) OffsetResponse(topic=u'test_send_offset_request-SMTPHcxJLm', partition=0, error=6, offsets=())
    afkak.test.int.test_client_integration.TestAfkakClientIntegration.test_send_offset_request

Simply wait for topic auto-create to complete.