### PR TITLE
Version and readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ See [AUTHORS.md](./AUTHORS.md) for the full contributor list.
 In order to run Afkak's tests, you need to install the
 dependencies as specified in the [install](#install) section.
 
-Afkak test suite uses [Tox](https://tox.readthedocs.io) to execute the tests
+The Afkak test suite uses [Tox](https://tox.readthedocs.io) to execute the tests
 in all the supported Python versions.
 The preferred method to run the tests is to install Tox in a virtual
 environment before running the tests:
@@ -214,21 +214,22 @@ make venv
 
 ### Run the unit tests
 
-To run all unit tests against all the supported Python versions (requires all
+To run all unit tests in all the supported Python versions (requires all
 the versions to be installed in the system where the tests will run):
 
 ```shell
 make toxu
 ```
 
-Alternatively, you might want to run unit tests against a list of specific
+Alternatively, you might want to run unit tests in a list of specific
 Python versions:
 
 ```shell
 .env/bin/tox -e py27-unit-snappy,py35-unit-snappy
 ```
 
-Contributors should run tests against all the supported Python versions.
+It is recommended for contributors to run unit tests in at least Python 2.7 and
+one Python 3 version before submitting a pull request.
 
 ### Run the integration tests
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Alternatively, you might want to run unit tests against a list of specific
 Python versions:
 
 ```shell
-./env/bin/tox -e py27-unit-snappy,py35-unit-snappy
+.env/bin/tox -e py27-unit-snappy,py35-unit-snappy
 ```
 
 Contributors should run tests against all the supported Python versions.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ resps[0].offset     # offset of the first message sent in this request
 
 Afkak releases are [available on PyPI][afkak-pypi].
 
-Because the Afkak dependencies [Twisted][twisted] and [python-snappy][python-snappy] have binary extension modules you will need to install the Python development headers for the interpreter you wish to use.  You'll need all of these to run Afkak's tests:
+Because the Afkak dependencies [Twisted][twisted] and [python-snappy][python-snappy] have binary extension modules you will need to install the Python development headers for the interpreter you wish to use:
 
 [afkak-pypi]: https://pypi.python.org/pypi/afkak
 [twisted]: https://pypi.python.org/pypi/Twisted
@@ -200,11 +200,37 @@ See [AUTHORS.md](./AUTHORS.md) for the full contributor list.
 
 # Tests
 
+In order to run Afkak's tests, you need to install the
+dependencies as specified in the [install](#install) section.
+
+Afkak test suite uses [Tox](https://tox.readthedocs.io) to execute the tests
+in all the supported Python versions.
+The preferred method to run the tests is to install Tox in a virtual
+environment before running the tests:
+
+```shell
+make venv
+```
+
+
 ### Run the unit tests
+
+To run all unit tests against all the supported Python versions:
 
 ```shell
 make toxu
 ```
+
+In order for the tests to complete successfully, you will need to have all the
+supported Python versions installed in the system where the tests will run.
+Alternatively, you might want to run unit tests against a list of specific
+Python versions:
+
+```shell
+./env/bin/tox -e py27-unit-snappy,py35-unit-snappy
+```
+
+Contributors should run tests against all the supported Python versions.
 
 ### Run the integration tests
 

--- a/README.md
+++ b/README.md
@@ -212,17 +212,15 @@ environment before running the tests:
 make venv
 ```
 
-
 ### Run the unit tests
 
-To run all unit tests against all the supported Python versions:
+To run all unit tests against all the supported Python versions (requires all
+the versions to be installed in the system where the tests will run):
 
 ```shell
 make toxu
 ```
 
-In order for the tests to complete successfully, you will need to have all the
-supported Python versions installed in the system where the tests will run.
 Alternatively, you might want to run unit tests against a list of specific
 Python versions:
 

--- a/afkak/__init__.py
+++ b/afkak/__init__.py
@@ -17,7 +17,7 @@ from .producer import Producer
 
 # Note, you need to bump the version in setup.py as well
 __title__ = 'afkak'
-__version__ = "3.0.0.dev0"  # Makefile parses this. Retain formatting.
+__version__ = "19.6.0a1"  # Makefile parses this. Retain formatting.
 __author__ = 'Robert Thille'
 __license__ = 'Apache License 2.0'
 


### PR DESCRIPTION
Make targets are failing due to the discrepancy in versions between `setup.py` and `__init__.py`.
Updates to the `README.md` that I believe make it easier for new contributors to get started.