### PR TITLE
Non recursive consumer message processing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+Version 19.8.0b1
+================
+
+* `afkak.consumer.Consumer._process_messages` has been modified to avoid using recursive callbacks that could result in a `RecursionError`.
+
+  Fixes [#93](https://github.com/ciena/afkak/issues/93).
+
 Version 19.6.0a1
 ================
 

--- a/afkak/test/test_consumer.py
+++ b/afkak/test/test_consumer.py
@@ -1757,8 +1757,7 @@ class TestAfkakConsumer(unittest.TestCase):
         consumer = Consumer(
             client, 'a_topic', a_partition, a_processor, a_consumer_group,
         )
-
-        self.assertIsNone(consumer._process_messages([]))
+        self.assertEqual(self.successResultOf(consumer._process_messages([])), None)
 
     def test_consumer_process_messages_stack_safe(self):
         """

--- a/afkak/test/test_consumer.py
+++ b/afkak/test/test_consumer.py
@@ -18,7 +18,7 @@ import logging
 import sys
 
 from mock import ANY, Mock, call, patch
-from twisted.internet.defer import CancelledError, Deferred, DeferredList, fail, succeed
+from twisted.internet.defer import CancelledError, Deferred, DeferredList, fail
 from twisted.python.failure import Failure
 from twisted.test.proto_helpers import MemoryReactorClock
 from twisted.trial import unittest
@@ -1757,7 +1757,7 @@ class TestAfkakConsumer(unittest.TestCase):
         consumer = Consumer(
             client, 'a_topic', a_partition, a_processor, a_consumer_group,
         )
-        self.assertEqual(self.successResultOf(consumer._process_messages([])), None)
+        self.assertIsNone(self.successResultOf(consumer._process_messages([])))
 
     def test_consumer_process_messages_stack_safe(self):
         """


### PR DESCRIPTION
This addresses the issue identified in #93 which is caused by the way  `_process_messages` uses a callback chain to itself to process a large batch of messages.
This logic has been changed to use a simple while loop. Since we want to avoid processing a batch of messages until the current batch has been committed, the while loop `yield`s until the `Deferred` returned by the current processor has fired.

Unit tests required one change caused by the fact that now `_process_messages` returns a `Deferred` since it is decorated with `inlineCallbacks`

The debug statement that logs the result of the processor was moved to a callback function since otherwise it prints a `Deferred` object, not the actual return value of the processor function. This change is not part of the fix of the issue, but something additional that I noticed that seemed wrong to me.