### PR TITLE
Consumer offsets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+Version 19.8.0b2
+================
+
+* The `Consumer` class has grown read-only attributes `last_offset_processed` and `last_offset_committed`.
+
+* **Backwards incompatible:** The `Consumer.stop()` method and the deferreds returned by `Consumer.start()` and `Consumer.shutdown()` once again return the last processed offset, reverting a backwards-incompatible change in Afkak 19.6.0a1.
+
 Version 19.8.0b1
 ================
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Because the Afkak dependencies [Twisted][twisted] and [python-snappy][python-sna
 <table>
 <tr>
 <td>Debian/Ubuntu:
-<td><code>sudo apt-get install build-essential python-dev python3-dev pypy-dev libsnappy-dev</code>
+<td><code>sudo apt-get install build-essential python-dev python3-dev pypy-dev pypy3-dev libsnappy-dev</code>
 <tr>
 <td>OS X
 <td><code>brew install python pypy snappy</code></br>

--- a/afkak/consumer.py
+++ b/afkak/consumer.py
@@ -451,8 +451,7 @@ class Consumer(object):
         if not d.called:
             d.callback(self._last_processed_offset)
 
-        # Return tuple with the offset of the message we last processed,
-        # and the offset we last committed
+        # Return the offset of the message we last processed.
         return self._last_processed_offset
 
     def commit(self):

--- a/afkak/consumer.py
+++ b/afkak/consumer.py
@@ -70,9 +70,9 @@ class Consumer(object):
       needed.
     - Once processing resolves, :attr:`.processor` will be called again with
       the next batch of messages.
-    - When desired, call :meth:`.stop` on the :class:`Consumer` to halt
-      calls to the :attr:`processor` function and cancel any outstanding
-      requests to the Kafka cluster.
+    - When desired, call :meth:`.shutdown` on the :class:`Consumer` to halt
+      calls to the :attr:`processor` function and commit progress (if
+      a *consumer_group* is specified).
 
     A :class:`Consumer` may be restarted once stopped.
 
@@ -150,8 +150,8 @@ class Consumer(object):
           consumer's default). The consumer will read messages once new
           messages are produced to the topic.
         - `None`: fail on `OffsetOutOfRangeError` (Afkak's default). The
-          `Deferred` returned by :meth:`Producer.start()` will errback. The caller
-          may call :meth:`~.start()` again with the desired offset.
+          `Deferred` returned by :meth:`Consumer.start()` will errback. The
+          caller may call :meth:`~.start()` again with the desired offset.
 
         The broker returns `OffsetOutOfRangeError` when the client requests an
         offset that isn't valid. This may mean that the requested offset no
@@ -449,8 +449,10 @@ class Consumer(object):
 
     def commit(self):
         """
-        Commit the offset of the message we last processed if it is different
-        from what we believe is the last offset committed to Kafka.
+        Commit the last processed offset
+
+        Immediately commit the value of :attr:`last_processed_offset` if it
+        differs from :attr:`last_committed_offset`.
 
         .. note::
 

--- a/afkak/consumer.py
+++ b/afkak/consumer.py
@@ -128,17 +128,6 @@ class Consumer(object):
         means retry forever; other values must be positive and indicate
         the number of attempts to make before returning failure.
 
-    :ivar last_processed_offset:
-        Offset of the last message that was successfully processed, or `None`
-        if no message has been processed yet (read-only). This is updated only
-        once the processor function returns and any deferred it returns
-        succeeds.
-    :type last_processed_offset: Optional[int]
-
-    :ivar last_committed_offset:
-        The last offset that was successfully commited to Kafka, or `None` if
-        no offset has been committed yet (read-only).
-    :type last_committed_offset: Optional[int]
 
     :ivar int auto_offset_reset:
         What action should be taken when the broker responds to a fetch request
@@ -264,8 +253,27 @@ class Consumer(object):
         )
         # TODO Add commit_consumer_id if applicable
 
-    last_processed_offset = property(lambda self: self._last_processed_offset)
-    last_committed_offset = property(lambda self: self._last_committed_offset)
+    @property
+    def last_processed_offset(self):
+        """
+        Offset of the last message that was successfully processed, or `None`
+        if no message has been processed yet (read-only). This is updated only
+        once the processor function returns and any deferred it returns
+        succeeds.
+
+        :rtype: Optional[int]
+        """
+        return self._last_processed_offset
+
+    @property
+    def last_committed_offset(self):
+        """
+        The last offset that was successfully commited to Kafka, or `None` if
+        no offset has been committed yet (read-only).
+
+        :rtype: Optional[int]
+        """
+        return self._last_committed_offset
 
     def start(self, start_offset):
         """

--- a/afkak/consumer.py
+++ b/afkak/consumer.py
@@ -92,7 +92,7 @@ class Consumer(object):
     :ivar str consumer_group:
         Optional consumer group ID for committing offsets of processed
         messages back to Kafka.
-    :ivar str commit_metadata:
+    :ivar bytes commit_metadata:
         Optional metadata to store with offsets commit.
     :ivar int auto_commit_every_n:
         Number of messages after which the consumer will automatically

--- a/afkak/test/int/test_consumer_integration.py
+++ b/afkak/test/int/test_consumer_integration.py
@@ -212,7 +212,7 @@ class TestConsumerIntegration(IntegrationMixin, unittest.TestCase):
 
         # Stop the consumer and record offset at which to restart (next after
         # last processed message offset)
-        offset = consumer.stop()[0] + 1
+        offset = consumer.stop() + 1
         self.successResultOf(start_d)
 
         # Send some more messages

--- a/afkak/test/test_consumer.py
+++ b/afkak/test/test_consumer.py
@@ -43,6 +43,9 @@ log = logging.getLogger(__name__)
 class TestAfkakConsumer(unittest.SynchronousTestCase):
     maxDiff = None
 
+    def assertNone(self, value):
+        self.assertIs(None, value)
+
     def test_consumer_non_integer_partitions(self):
         with self.assertRaises(ValueError):
             Consumer(Mock(), 'topic', '0', Mock())
@@ -153,8 +156,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         mockclient.send_fetch_request.assert_called_once_with(
             [request], max_wait_time=consumer.fetch_max_wait_time,
             min_bytes=consumer.fetch_min_bytes)
-        consumer.stop()
-        self.assertEqual(self.successResultOf(d), (None, None))
+        self.assertNone(consumer.stop())
+        self.assertNone(self.successResultOf(d))
 
     def test_consumer_start_earliest(self):
         clock = MemoryReactorClock()
@@ -163,8 +166,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         d = consumer.start(OFFSET_EARLIEST)
         request = OffsetRequest(u'earliestTopic', 9, OFFSET_EARLIEST, 1)
         mockclient.send_offset_request.assert_called_once_with([request])
-        consumer.stop()
-        self.assertEqual(self.successResultOf(d), (None, None))
+        self.assertNone(consumer.stop())
+        self.assertNone(self.successResultOf(d))
 
     def test_consumer_start_latest(self):
         offset = 2346  # arbitrary
@@ -190,8 +193,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             [request], max_wait_time=consumer.fetch_max_wait_time,
             min_bytes=consumer.fetch_min_bytes)
         # Stop the consumer to cleanup any outstanding operations
-        consumer.stop()
-        self.assertEqual(self.successResultOf(d), (None, None))
+        self.assertNone(consumer.stop())
+        self.assertNone(self.successResultOf(d))
 
     def test_consumer_start_committed(self):
         offset = 2996  # arbitrary, offset we're committing
@@ -221,8 +224,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             [request], max_wait_time=consumer.fetch_max_wait_time,
             min_bytes=consumer.fetch_min_bytes)
         # Stop the consumer to cleanup any outstanding operations
-        consumer.stop()
-        self.assertEqual(self.successResultOf(d), (None, 2996))
+        self.assertNone(consumer.stop())
+        self.assertNone(self.successResultOf(d))
 
     def test_consumer_start_committed_bad_group(self):
         clock = MemoryReactorClock()
@@ -338,8 +341,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         # Stop the consumer to cleanup any outstanding operations
         self.assertNoResult(start_d)
         last_processed = consumer.stop()
-        self.assertEqual(self.successResultOf(start_d), (the_offset, the_offset))
-        self.assertEqual(last_processed, (the_offset, the_offset))
+        self.assertEqual(self.successResultOf(start_d), the_offset)
+        self.assertEqual(last_processed, the_offset)
 
     def test_consumer_commit_retry(self):
         mockclient = Mock(reactor=MemoryReactorClock())
@@ -463,8 +466,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         request = OffsetRequest(topic, part, OFFSET_LATEST, 1)
         mockclient.send_offset_request.assert_called_once_with([request])
         # Stop the consumer to cleanup any outstanding operations
-        consumer.stop()
-        self.assertEqual(self.successResultOf(d), (None, None))
+        self.assertNone(consumer.stop())
+        self.assertNone(self.successResultOf(d))
 
     def test_consumer_stop_before_fetch_response(self):
         """test_consumer_stop_before_fetch_response
@@ -505,7 +508,7 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             min_bytes=consumer.fetch_min_bytes)
         # Fire a response to the fetch request
         req_ds[0].callback(make_response(offset))
-        self.assertEqual(self.successResultOf(start_d), (None, None))
+        self.assertNone(self.successResultOf(start_d))
         clock.advance(consumer.retry_max_delay)
         expected_calls = [
             call([request], max_wait_time=consumer.fetch_max_wait_time,
@@ -528,8 +531,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             klog.debug.assert_called_once_with(
                 "%r: Failure fetching messages from kafka: %r",
                 consumer, f)
-        consumer.stop()
-        self.assertEqual(self.successResultOf(d), (None, None))
+        self.assertNone(consumer.stop())
+        self.assertNone(self.successResultOf(d))
 
     def test_consumer_offset_fetch_retry_to_failure(self):
         """
@@ -559,7 +562,7 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         offset_call = call([request])
         self.assertEqual(mockclient.send_offset_request.mock_calls,
                          [offset_call] * fetch_attempts)
-        consumer.stop()
+        self.assertNone(consumer.stop())
 
     def test_consumer_fetch_retry_to_failure(self):
 
@@ -589,7 +592,7 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             min_bytes=consumer.fetch_min_bytes)
         self.assertEqual(mockclient.send_fetch_request.mock_calls,
                          [fetch_call] * fetch_attempts)
-        consumer.stop()
+        self.assertNone(consumer.stop())
 
     def test_consumer_stop_during_initial_proc_call(self):
         # processor's deferred
@@ -635,7 +638,7 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         self.assertTrue(pmock_errback.called)
 
         # Make sure the start callback was called, and the errback wasn't
-        self.assertEqual(self.successResultOf(start_d), (None, None))
+        self.assertNone(self.successResultOf(start_d))
 
     def test_consumer_stop_during_commit_retry(self):
         # setup a client which will return a message block in response to fetch
@@ -675,8 +678,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         commit_d = consumer.commit()
         self.assertNoResult(commit_d)
 
-        consumer.stop()
-        self.assertEqual(self.successResultOf(d), (1, None))
+        self.assertEqual(1, consumer.stop())
+        self.assertEqual(1, self.successResultOf(d))
         # Now the commit_d should have been cancelled, check for the failure
         self.failureResultOf(commit_d, CancelledError)
 
@@ -703,8 +706,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         self.assertEqual(consumer._commit_ds[0], commit_d)
 
         # Stop the consumer, assert the start_d fired, and commit_d errbacks
-        consumer.stop()
-        self.assertEqual(self.successResultOf(start_d), (0, None))
+        self.assertEqual(the_offset, consumer.stop())
+        self.assertEqual(the_offset, self.successResultOf(start_d))
         self.failureResultOf(commit_d, CancelledError)
 
     def test_consumer_stop_not_started(self):
@@ -747,8 +750,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         proc_d.errback(f)
         # Ensure the start() deferred was errback'd
         self.assertEqual(self.failureResultOf(d), f)
-
-        consumer.stop()
+        self.assertNone(consumer.stop())
+        self.assertNone(consumer.last_processed_offset)
 
     def test_consumer_error_during_offset(self):
         topic = 'error_during_offset'
@@ -771,8 +774,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         self.assertEqual(2, mockclient.send_offset_request.call_count)
 
         # Stop the consumer to cleanup any outstanding operations
-        consumer.stop()
-        self.assertEqual(self.successResultOf(d), (None, None))
+        self.assertNone(consumer.stop())
+        self.assertNone(self.successResultOf(d))
 
     def test_consumer_offset_out_of_range_error_with_auto_reset_to_earliest(self):
         topic = 'offset_out_of_range_error'
@@ -943,8 +946,10 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         self.assertEqual(None, consumer._request_d)
 
         # stop consumer to clean up
-        consumer.stop()
-        self.assertEqual(self.successResultOf(d), (1967, None))
+        self.assertEqual(offset, consumer.stop())
+        self.assertEqual(offset, self.successResultOf(d))
+        self.assertEqual(offset, consumer.last_processed_offset)
+        self.assertNone(consumer.last_committed_offset)
 
     def test_consumer_fetch_large_message(self):
         topic = 'fetch_large_message'
@@ -979,8 +984,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             # Advance the clock to trigger the next request
             clock.advance(0.1)
 
-        consumer.stop()
-        self.assertEqual(self.successResultOf(d), (0, None))
+        self.assertEqual(0, consumer.stop())
+        self.assertEqual(0, self.successResultOf(d))
 
     def test_consumer_fetch_too_large_message(self):
         topic = 'fetch_too_large_message'
@@ -1054,8 +1059,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         # Make sure the processor was called
         self.assertTrue(mock_proc.called)
 
-        consumer.stop()
-        self.assertEqual(self.successResultOf(d), (1, None))
+        self.assertEqual(1, consumer.stop())
+        self.assertEqual(1, self.successResultOf(d))
 
     def test_consumer_do_fetch_not_reentrant(self):
         # This test is a bit of a hack to get coverage
@@ -1081,8 +1086,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             [request], max_wait_time=consumer.fetch_max_wait_time,
             min_bytes=consumer.fetch_min_bytes)
         # clean up
-        consumer.stop()
-        self.assertEqual(self.successResultOf(d), (None, None))
+        self.assertNone(consumer.stop())
+        self.assertNone(self.successResultOf(d))
 
     def test_consumer_do_fetch_before_retry_call(self):
         # This test is a bit of a hack to get coverage
@@ -1110,8 +1115,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             consumer._do_fetch()
 
         # clean up
-        consumer.stop()
-        self.assertEqual(self.successResultOf(d), (None, None))
+        self.assertNone(consumer.stop())
+        self.assertNone(self.successResultOf(d))
 
     def test_consumer_autocommit_during_commit(self):
         clock = MemoryReactorClock()
@@ -1229,8 +1234,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         # Check that the looping call was restarted
         self.assertTrue(consumer._commit_looper.running)
 
-        consumer.stop()
-        self.assertEqual(self.successResultOf(start_d), (the_offset, None))
+        self.assertEqual(the_offset, consumer.stop())
+        self.assertEqual(the_offset, self.successResultOf(start_d))
 
     def test_consumer_send_timer_stopped_error(self):
         # Purely for coverage
@@ -1274,9 +1279,9 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         # Shutdown the consumer
         shutdown_d = consumer.shutdown()
         # Ensure the stop was signaled
-        self.assertEqual(self.successResultOf(start_d), (None, None))
+        self.assertNone(self.successResultOf(start_d))
         # Ensure the shutdown was signaled
-        self.assertEqual(self.successResultOf(shutdown_d), (None, None))
+        self.assertNone(self.successResultOf(shutdown_d))
         # Ensure the processor was never called
         self.assertFalse(mockproc.called)
 
@@ -1298,9 +1303,9 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         # Shutdown the consumer
         shutdown_d = consumer.shutdown()
         # Ensure the stop was signaled
-        self.assertEqual(self.successResultOf(start_d), (None, None))
+        self.assertNone(self.successResultOf(start_d))
         # Ensure the shutdown was signaled
-        self.assertEqual(self.successResultOf(shutdown_d), (None, None))
+        self.assertNone(self.successResultOf(shutdown_d))
         # Ensure the processor was never called
         self.assertFalse(mockproc.called)
 
@@ -1351,9 +1356,11 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         # Indicate a successful commit
         commit_d[0].callback(consumer._last_processed_offset)
         # Ensure the stop was signaled
-        self.assertEqual(self.successResultOf(start_d), (6, 6))
+        self.assertEqual(6, self.successResultOf(start_d))
         # Ensure the shutdown was signaled
-        self.assertEqual(self.successResultOf(shutdown_d), (6, 6))
+        self.assertEqual(6, self.successResultOf(shutdown_d))
+        self.assertEqual(6, consumer.last_processed_offset)
+        self.assertEqual(6, consumer.last_committed_offset)
 
     def test_consumer_shutdown_commit_in_progress(self):
         """test_consumer_shutdown_commit_in_progress
@@ -1408,9 +1415,9 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         # Indicate a successful commit
         commit_ds[0].callback(consumer._last_processed_offset)
         # Ensure the stop was signaled
-        self.assertEqual((7, 7), self.successResultOf(start_d))
+        self.assertEqual(7, self.successResultOf(start_d))
         # Ensure the shutdown was signaled
-        self.assertEqual((7, 7), self.successResultOf(shutdown_d))
+        self.assertEqual(7, self.successResultOf(shutdown_d))
 
     def test_consumer_shutdown_commit_failure(self):
         """test_consumer_shutdown_commit_failure
@@ -1458,7 +1465,9 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         the_fail = Failure(RuntimeError('Unretryable Commit Failure'))
         commit_d[0].errback(the_fail)
         # Ensure the stop was signaled with nothing committed
-        self.assertEqual((6, None), self.successResultOf(start_d))
+        self.assertEqual(6, self.successResultOf(start_d))
+        self.assertEqual(6, consumer.last_processed_offset)
+        self.assertNone(consumer.last_committed_offset)
         # Ensure the shutdown was signaled as an errback
         self.assertEqual(the_fail, self.failureResultOf(shutdown_d))
 
@@ -1512,7 +1521,9 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         # Ensure the stop was signaled with the failure
         self.assertEqual(self.failureResultOf(start_d), the_fail)
         # Ensure the shutdown was signaled as a callback, not errback
-        self.assertEqual(self.successResultOf(shutdown_d), (None, None))
+        self.assertNone(self.successResultOf(shutdown_d))
+        self.assertNone(consumer.last_processed_offset)
+        self.assertNone(consumer.last_committed_offset)
 
     def test_consumer_shutdown_processor_immediate_shutdown(self):
         """
@@ -1571,9 +1582,9 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         assert isinstance(commit_fail, Failure)
         commit_fail.trap(CancelledError)
         # Ensure the stop (start_d) was signaled with success
-        self.assertEqual(self.successResultOf(start_d), (None, None))
+        self.assertNone(self.successResultOf(start_d))
         # Ensure the shutdown was signaled as a callback, not errback
-        self.assertEqual(self.successResultOf(proc_l[0]), (None, None))
+        self.assertNone(self.successResultOf(proc_l[0]))
 
     def test_consumer_shutdown_called_twice(self):
         """
@@ -1624,9 +1635,9 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         proc_d.callback(None)
         commit_d[0].callback(consumer._last_processed_offset)
         # Ensure the stop (start_d) was signaled with success
-        self.assertEqual(self.successResultOf(start_d), (6, 6))
+        self.assertEqual(6, self.successResultOf(start_d))
         # Ensure the shutdown was signaled as a callback, not errback
-        self.assertEqual(self.successResultOf(shutdown_d), (6, 6))
+        self.assertEqual(6, self.successResultOf(shutdown_d))
 
     def test_consumer_shutdown_when_not_started(self):
         """
@@ -1698,11 +1709,13 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         commit_d = consumer.commit()
         # the commit call should have short-circuited due to lack of
         # processing anything up to now.
-        self.assertEqual(self.successResultOf(commit_d), 1234)
+        self.assertEqual(1234, self.successResultOf(commit_d))
         self.assertFalse(mockclient.send_offset_commit_request.called)
         # Stop the consumer to cleanup any outstanding operations
-        consumer.stop()
-        self.assertEqual(self.successResultOf(start_d), (None, 1234))
+        self.assertNone(consumer.stop())
+        self.assertNone(self.successResultOf(start_d))
+        self.assertNone(consumer.last_processed_offset)
+        self.assertEqual(1234, consumer.last_committed_offset)
 
     def test_consumer_consume_committed_no_offset_stored(self):
         """
@@ -1745,8 +1758,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             [request], max_wait_time=consumer.fetch_max_wait_time,
             min_bytes=consumer.fetch_min_bytes)
         # Stop the consumer to cleanup any outstanding operations
-        consumer.stop()
-        self.assertEqual(self.successResultOf(d), (None, None))
+        self.assertNone(consumer.stop())
+        self.assertNone(self.successResultOf(d))
 
     def test_consumer_process_messages_should_exit_when_no_messages_left(self):
         client = Mock()

--- a/afkak/test/test_consumer.py
+++ b/afkak/test/test_consumer.py
@@ -43,9 +43,6 @@ log = logging.getLogger(__name__)
 class TestAfkakConsumer(unittest.SynchronousTestCase):
     maxDiff = None
 
-    def assertNone(self, value):
-        self.assertIs(None, value)
-
     def test_consumer_non_integer_partitions(self):
         with self.assertRaises(ValueError):
             Consumer(Mock(), 'topic', '0', Mock())
@@ -156,8 +153,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         mockclient.send_fetch_request.assert_called_once_with(
             [request], max_wait_time=consumer.fetch_max_wait_time,
             min_bytes=consumer.fetch_min_bytes)
-        self.assertNone(consumer.stop())
-        self.assertNone(self.successResultOf(d))
+        self.assertIsNone(consumer.stop())
+        self.assertIsNone(self.successResultOf(d))
 
     def test_consumer_start_earliest(self):
         clock = MemoryReactorClock()
@@ -166,8 +163,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         d = consumer.start(OFFSET_EARLIEST)
         request = OffsetRequest(u'earliestTopic', 9, OFFSET_EARLIEST, 1)
         mockclient.send_offset_request.assert_called_once_with([request])
-        self.assertNone(consumer.stop())
-        self.assertNone(self.successResultOf(d))
+        self.assertIsNone(consumer.stop())
+        self.assertIsNone(self.successResultOf(d))
 
     def test_consumer_start_latest(self):
         offset = 2346  # arbitrary
@@ -193,8 +190,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             [request], max_wait_time=consumer.fetch_max_wait_time,
             min_bytes=consumer.fetch_min_bytes)
         # Stop the consumer to cleanup any outstanding operations
-        self.assertNone(consumer.stop())
-        self.assertNone(self.successResultOf(d))
+        self.assertIsNone(consumer.stop())
+        self.assertIsNone(self.successResultOf(d))
 
     def test_consumer_start_committed(self):
         offset = 2996  # arbitrary, offset we're committing
@@ -224,8 +221,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             [request], max_wait_time=consumer.fetch_max_wait_time,
             min_bytes=consumer.fetch_min_bytes)
         # Stop the consumer to cleanup any outstanding operations
-        self.assertNone(consumer.stop())
-        self.assertNone(self.successResultOf(d))
+        self.assertIsNone(consumer.stop())
+        self.assertIsNone(self.successResultOf(d))
 
     def test_consumer_start_committed_bad_group(self):
         clock = MemoryReactorClock()
@@ -466,8 +463,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         request = OffsetRequest(topic, part, OFFSET_LATEST, 1)
         mockclient.send_offset_request.assert_called_once_with([request])
         # Stop the consumer to cleanup any outstanding operations
-        self.assertNone(consumer.stop())
-        self.assertNone(self.successResultOf(d))
+        self.assertIsNone(consumer.stop())
+        self.assertIsNone(self.successResultOf(d))
 
     def test_consumer_stop_before_fetch_response(self):
         """test_consumer_stop_before_fetch_response
@@ -508,7 +505,7 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             min_bytes=consumer.fetch_min_bytes)
         # Fire a response to the fetch request
         req_ds[0].callback(make_response(offset))
-        self.assertNone(self.successResultOf(start_d))
+        self.assertIsNone(self.successResultOf(start_d))
         clock.advance(consumer.retry_max_delay)
         expected_calls = [
             call([request], max_wait_time=consumer.fetch_max_wait_time,
@@ -531,8 +528,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             klog.debug.assert_called_once_with(
                 "%r: Failure fetching messages from kafka: %r",
                 consumer, f)
-        self.assertNone(consumer.stop())
-        self.assertNone(self.successResultOf(d))
+        self.assertIsNone(consumer.stop())
+        self.assertIsNone(self.successResultOf(d))
 
     def test_consumer_offset_fetch_retry_to_failure(self):
         """
@@ -562,7 +559,7 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         offset_call = call([request])
         self.assertEqual(mockclient.send_offset_request.mock_calls,
                          [offset_call] * fetch_attempts)
-        self.assertNone(consumer.stop())
+        self.assertIsNone(consumer.stop())
 
     def test_consumer_fetch_retry_to_failure(self):
 
@@ -592,7 +589,7 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             min_bytes=consumer.fetch_min_bytes)
         self.assertEqual(mockclient.send_fetch_request.mock_calls,
                          [fetch_call] * fetch_attempts)
-        self.assertNone(consumer.stop())
+        self.assertIsNone(consumer.stop())
 
     def test_consumer_stop_during_initial_proc_call(self):
         # processor's deferred
@@ -638,7 +635,7 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         self.assertTrue(pmock_errback.called)
 
         # Make sure the start callback was called, and the errback wasn't
-        self.assertNone(self.successResultOf(start_d))
+        self.assertIsNone(self.successResultOf(start_d))
 
     def test_consumer_stop_during_commit_retry(self):
         # setup a client which will return a message block in response to fetch
@@ -750,8 +747,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         proc_d.errback(f)
         # Ensure the start() deferred was errback'd
         self.assertEqual(self.failureResultOf(d), f)
-        self.assertNone(consumer.stop())
-        self.assertNone(consumer.last_processed_offset)
+        self.assertIsNone(consumer.stop())
+        self.assertIsNone(consumer.last_processed_offset)
 
     def test_consumer_error_during_offset(self):
         topic = 'error_during_offset'
@@ -774,8 +771,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         self.assertEqual(2, mockclient.send_offset_request.call_count)
 
         # Stop the consumer to cleanup any outstanding operations
-        self.assertNone(consumer.stop())
-        self.assertNone(self.successResultOf(d))
+        self.assertIsNone(consumer.stop())
+        self.assertIsNone(self.successResultOf(d))
 
     def test_consumer_offset_out_of_range_error_with_auto_reset_to_earliest(self):
         topic = 'offset_out_of_range_error'
@@ -949,7 +946,7 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         self.assertEqual(offset, consumer.stop())
         self.assertEqual(offset, self.successResultOf(d))
         self.assertEqual(offset, consumer.last_processed_offset)
-        self.assertNone(consumer.last_committed_offset)
+        self.assertIsNone(consumer.last_committed_offset)
 
     def test_consumer_fetch_large_message(self):
         topic = 'fetch_large_message'
@@ -1086,8 +1083,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             [request], max_wait_time=consumer.fetch_max_wait_time,
             min_bytes=consumer.fetch_min_bytes)
         # clean up
-        self.assertNone(consumer.stop())
-        self.assertNone(self.successResultOf(d))
+        self.assertIsNone(consumer.stop())
+        self.assertIsNone(self.successResultOf(d))
 
     def test_consumer_do_fetch_before_retry_call(self):
         # This test is a bit of a hack to get coverage
@@ -1115,8 +1112,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             consumer._do_fetch()
 
         # clean up
-        self.assertNone(consumer.stop())
-        self.assertNone(self.successResultOf(d))
+        self.assertIsNone(consumer.stop())
+        self.assertIsNone(self.successResultOf(d))
 
     def test_consumer_autocommit_during_commit(self):
         clock = MemoryReactorClock()
@@ -1279,9 +1276,9 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         # Shutdown the consumer
         shutdown_d = consumer.shutdown()
         # Ensure the stop was signaled
-        self.assertNone(self.successResultOf(start_d))
+        self.assertIsNone(self.successResultOf(start_d))
         # Ensure the shutdown was signaled
-        self.assertNone(self.successResultOf(shutdown_d))
+        self.assertIsNone(self.successResultOf(shutdown_d))
         # Ensure the processor was never called
         self.assertFalse(mockproc.called)
 
@@ -1303,9 +1300,9 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         # Shutdown the consumer
         shutdown_d = consumer.shutdown()
         # Ensure the stop was signaled
-        self.assertNone(self.successResultOf(start_d))
+        self.assertIsNone(self.successResultOf(start_d))
         # Ensure the shutdown was signaled
-        self.assertNone(self.successResultOf(shutdown_d))
+        self.assertIsNone(self.successResultOf(shutdown_d))
         # Ensure the processor was never called
         self.assertFalse(mockproc.called)
 
@@ -1467,7 +1464,7 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         # Ensure the stop was signaled with nothing committed
         self.assertEqual(6, self.successResultOf(start_d))
         self.assertEqual(6, consumer.last_processed_offset)
-        self.assertNone(consumer.last_committed_offset)
+        self.assertIsNone(consumer.last_committed_offset)
         # Ensure the shutdown was signaled as an errback
         self.assertEqual(the_fail, self.failureResultOf(shutdown_d))
 
@@ -1521,9 +1518,9 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         # Ensure the stop was signaled with the failure
         self.assertEqual(self.failureResultOf(start_d), the_fail)
         # Ensure the shutdown was signaled as a callback, not errback
-        self.assertNone(self.successResultOf(shutdown_d))
-        self.assertNone(consumer.last_processed_offset)
-        self.assertNone(consumer.last_committed_offset)
+        self.assertIsNone(self.successResultOf(shutdown_d))
+        self.assertIsNone(consumer.last_processed_offset)
+        self.assertIsNone(consumer.last_committed_offset)
 
     def test_consumer_shutdown_processor_immediate_shutdown(self):
         """
@@ -1582,9 +1579,9 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         assert isinstance(commit_fail, Failure)
         commit_fail.trap(CancelledError)
         # Ensure the stop (start_d) was signaled with success
-        self.assertNone(self.successResultOf(start_d))
+        self.assertIsNone(self.successResultOf(start_d))
         # Ensure the shutdown was signaled as a callback, not errback
-        self.assertNone(self.successResultOf(proc_l[0]))
+        self.assertIsNone(self.successResultOf(proc_l[0]))
 
     def test_consumer_shutdown_called_twice(self):
         """
@@ -1712,9 +1709,9 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
         self.assertEqual(1234, self.successResultOf(commit_d))
         self.assertFalse(mockclient.send_offset_commit_request.called)
         # Stop the consumer to cleanup any outstanding operations
-        self.assertNone(consumer.stop())
-        self.assertNone(self.successResultOf(start_d))
-        self.assertNone(consumer.last_processed_offset)
+        self.assertIsNone(consumer.stop())
+        self.assertIsNone(self.successResultOf(start_d))
+        self.assertIsNone(consumer.last_processed_offset)
         self.assertEqual(1234, consumer.last_committed_offset)
 
     def test_consumer_consume_committed_no_offset_stored(self):
@@ -1758,8 +1755,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
             [request], max_wait_time=consumer.fetch_max_wait_time,
             min_bytes=consumer.fetch_min_bytes)
         # Stop the consumer to cleanup any outstanding operations
-        self.assertNone(consumer.stop())
-        self.assertNone(self.successResultOf(d))
+        self.assertIsNone(consumer.stop())
+        self.assertIsNone(self.successResultOf(d))
 
     def test_consumer_process_messages_should_exit_when_no_messages_left(self):
         client = Mock()


### PR DESCRIPTION
- Revert a backwards-incompatible change that was made as part of the coordinated consumer support. I'm not sure why this was done, as `ConsumerGroup` doesn't actually look at the result of stopping its consumers.
- Add attributes that expose some of the consumer's offset information. These will be useful as metrics.