### PR TITLE
Consumer logging tweaks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Version Next
+==============
+
+* The repr of the `afkak.Consumer` class no longer separates fields with commas.
+
 Version 19.8.0
 ==============
 

--- a/afkak/consumer.py
+++ b/afkak/consumer.py
@@ -247,7 +247,7 @@ class Consumer(object):
             raise ValueError('partition parameter must be subtype of Integral')
 
     def __repr__(self):
-        return '<{} {} topic={}, partition={}, processor={}>'.format(
+        return '<{} {} topic={} partition={} processor={}>'.format(
             self.__class__.__name__, self._state,
             self.topic, self.partition, self.processor,
         )

--- a/afkak/consumer.py
+++ b/afkak/consumer.py
@@ -643,7 +643,7 @@ class Consumer(object):
         return result
 
     def _update_processed_offset(self, result, offset):
-        log.debug('self.processor return: %r, last_offset: %r', result, offset)
+        log.debug('%s: processor returned %r at offset %d', self, result, offset)
         self._last_processed_offset = offset
         self._auto_commit(by_count=True)
 


### PR DESCRIPTION
Add some context to the log message `Consumer` generates when the processor function returns. It logged the offset, but not the partition, which isn't meaningful.