### PR TITLE
Consumer logging tweaks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,11 @@
 Version Next
 ==============
 
-* The repr of the `afkak.Consumer` class no longer separates fields with commas.
+* **Feature:**  The repr of the `afkak.Consumer` class has been cleaned up to make log messages that include it less noisy.
+   It now looks like ``<Consumer topicname/0 running>`` where ``0`` is the partition number.
+
+* **Feature:** Additional contextual information has been added to several of `afkak.Consumer` debug log messages.
+
 
 Version 19.8.0
 ==============

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Version Next
+==============
+
+* The repr of the `afkak.Consumer` class no longer separates fields with commas.
+
 Version 19.8.0
 ==============
 

--- a/afkak/consumer.py
+++ b/afkak/consumer.py
@@ -247,7 +247,7 @@ class Consumer(object):
             raise ValueError('partition parameter must be subtype of Integral')
 
     def __repr__(self):
-        return '<{} {} topic={}, partition={}, processor={}>'.format(
+        return '<{} {} topic={} partition={} processor={}>'.format(
             self.__class__.__name__, self._state,
             self.topic, self.partition, self.processor,
         )

--- a/afkak/consumer.py
+++ b/afkak/consumer.py
@@ -643,7 +643,7 @@ class Consumer(object):
         return result
 
     def _update_processed_offset(self, result, offset):
-        log.debug('self.processor return: %r, last_offset: %r', result, offset)
+        log.debug('%s: processor returned %r at offset %d', self, result, offset)
         self._last_processed_offset = offset
         self._auto_commit(by_count=True)
 

--- a/afkak/consumer.py
+++ b/afkak/consumer.py
@@ -237,7 +237,7 @@ class Consumer(object):
         self._commit_call = None  # IDelayedCall for delayed commit retries
         self._msg_block_d = None  # deferred for each block of messages
         self._processor_d = None  # deferred for a result from processor
-        self._state = '[initialized]'  # Keep track of state for debugging
+        self._state = 'initialized'  # Keep track of state for debugging
         # Check parameters for sanity
         if max_buffer_size is not None and buffer_size > max_buffer_size:
             raise ValueError("buffer_size (%d) is greater than "
@@ -247,9 +247,8 @@ class Consumer(object):
             raise ValueError('partition parameter must be subtype of Integral')
 
     def __repr__(self):
-        return '<{} {} topic={} partition={} processor={}>'.format(
-            self.__class__.__name__, self._state,
-            self.topic, self.partition, self.processor,
+        return '<{} {}/{} {}>'.format(
+            self.__class__.__name__, self.topic, self.partition, self._state,
         )
         # TODO Add commit_consumer_id if applicable
 
@@ -309,7 +308,7 @@ class Consumer(object):
             raise RestartError("Start called on already-started consumer")
 
         # Keep track of state for debugging
-        self._state = '[started]'
+        self._state = 'started'
 
         # Create and return a deferred for alerting on errors/stoppage
         start_d = self._start_d = Deferred()
@@ -377,7 +376,7 @@ class Consumer(object):
         # feeding new messages to the processor, and fetches won't be retried
         self._shuttingdown = True
         # Keep track of state for debugging
-        self._state = '[shutting down]'
+        self._state = 'shutting down'
         # TODO: This was added as part of coordinated consumer support,
         # but it belongs in the constructor if it is even necessary.
         # don't let commit requests retry forever and prevent shutdown
@@ -412,7 +411,7 @@ class Consumer(object):
 
         self._stopping = True
         # Keep track of state for debugging
-        self._state = '[stopping]'
+        self._state = 'stopping'
         # Are we waiting for a request to come back?
         if self._request_d:
             self._request_d.cancel()
@@ -444,7 +443,7 @@ class Consumer(object):
         # Done stopping
         self._stopping = False
         # Keep track of state for debugging
-        self._state = '[stopped]'
+        self._state = 'stopped'
 
         # Clear and possibly callback our start() Deferred
         self._start_d, d = None, self._start_d

--- a/afkak/test/test_consumer.py
+++ b/afkak/test/test_consumer.py
@@ -137,12 +137,8 @@ class TestAfkakConsumer(unittest.SynchronousTestCase):
 
     def test_consumer_repr(self):
         mockClient = Mock(reactor=MemoryReactorClock())
-        processor = '<function consume_msgs() at 0x12345678>'
-        consumer = Consumer(mockClient, 'Grues', 99, processor)
-        self.assertEqual((
-            '<Consumer [initialized] topic=Grues, partition=99, '
-            'processor=<function consume_msgs() at 0x12345678>>'
-        ), repr(consumer))
+        consumer = Consumer(mockClient, 'Grues', 99, lambda c, m: None)
+        self.assertEqual('<Consumer Grues/99 initialized>', repr(consumer))
 
     def test_consumer_start_offset(self):
         clock = MemoryReactorClock()


### PR DESCRIPTION
Include the partition number when logging offsets, as the offset isn't meaningful otherwise.

Clean up the `Consumer` repr so that it has fewer sigils. Remove the processor function as it isn't usually useful information but tends to be quite long. I picked the convention of `{topic}/{partition}` as `/` isn't valid in a topic name. For example, `mymessages/0` for partition 0 of topic "mymessages". This will extend nicely once we have a multi-partition consumer to something like `mymessages/0,1,2`.