### PR TITLE
Accept bootstrap hosts as tuples

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+Version Next
+==============
+
+- **Feature:** `afkak.KafkaClient` now accepts a sequence ``(host, port)`` tuples as its ``hosts`` argument and when passed to the ``update_cluster_hosts()`` method.
+  This permits passing IPv6 addresses and fixes [#41](https://github.com/ciena/afkak/issues/41).
+
 Version 19.8.0
 ==============
 

--- a/afkak/client.py
+++ b/afkak/client.py
@@ -1258,8 +1258,14 @@ def _normalize_hosts(hosts):
     [('127.0.0.2', 2909), ('host', 9092)]
 
     :param hosts:
-        A list or comma-separated string of hostnames which may also include
-        port numbers. All of the following are valid::
+        One of:
+
+        - A comma-separated string of hostnames
+        - A sequence of strings of the form ``host`` or ``host:port``
+        - A sequence of two-tuples of the form ``('host', port)``
+
+        Types are aggressively coerced for the sake of backwards compatibility,
+        so all of the following are valid::
 
             b'host'
             u'host'
@@ -1268,6 +1274,7 @@ def _normalize_hosts(hosts):
             b'host:1234 , host:2345 '
             [u'host1', b'host2']
             [b'host:1234', b'host:2345']
+            [(b'host', 1234), (u'host', '234')]
 
         Hostnames must be ASCII (IDN is not supported). The default Kafka port
         of 9092 is implied when no port is given.
@@ -1282,9 +1289,13 @@ def _normalize_hosts(hosts):
 
     result = set()
     for host_port in hosts:
-        # FIXME This won't handle IPv6 addresses
-        res = nativeString(host_port).split(':')
-        host = res[0].strip()
-        port = int(res[1].strip()) if len(res) > 1 else DefaultKafkaPort
+        if isinstance(host_port, (bytes, _unicode)):
+            res = nativeString(host_port).split(':')
+            host = res[0].strip()
+            port = int(res[1].strip()) if len(res) > 1 else DefaultKafkaPort
+        else:
+            host, port = host_port
+            host = nativeString(host)
+            port = int(port)
         result.add((host, port))
     return sorted(result)

--- a/afkak/test/test_client.py
+++ b/afkak/test/test_client.py
@@ -1671,3 +1671,21 @@ class NormalizeHostsTests(unittest.TestCase):
         self.assertEqual([('kafka', 1234)], _normalize_hosts(u'kafka:1234 '))
         self.assertEqual([('kafka', 1234), ('kafka', 2345)], _normalize_hosts(u'kafka:1234 ,kafka:2345'))
         self.assertEqual([('1.2.3.4', 5555)], _normalize_hosts(b' 1.2.3.4:5555 '))
+
+    def test_sequence(self):
+        """
+        The input may be a sequence of hostnames or host ports. The default
+        port is implied when none is given.
+        """
+        self.assertEqual(
+            [('kafka', 9092)],
+            _normalize_hosts([u'kafka', b'kafka', ('kafka', 9092)]),
+        )
+        self.assertEqual(
+            [('kafka1', 9092), ('kafka2', 9092)],
+            _normalize_hosts([('kafka2', 9092), ('kafka1', 9092)]),
+        )
+        self.assertEqual(
+            [('kafka1', 1234), ('kafka2', 2345)],
+            _normalize_hosts([('kafka2', u'2345'), ('kafka1', b'1234')]),
+        )

--- a/afkak/test/test_client.py
+++ b/afkak/test/test_client.py
@@ -198,10 +198,26 @@ class TestKafkaClient(unittest.TestCase):
         self.assertRaises(Exception, KafkaClient, 'kafka.example.com', clientId='MyClient', timeout="100ms")
         self.assertRaises(TypeError, KafkaClient, 'kafka.example.com', clientId='MyClient', timeout=None)
 
+    def test_client_bad_hosts(self):
+        """
+        `KafkaClient.__init__` raises an exception when passed an invalid
+        *hosts* argument.
+        """
+        self.assertRaises(Exception, KafkaClient, hosts='foo:notaport')
+
     def test_update_cluster_hosts(self):
         c = KafkaClient(hosts='www.example.com')
         c.update_cluster_hosts('meep.org')
         self.assertEqual(c._bootstrap_hosts, [('meep.org', 9092)])
+
+    def test_update_cluster_hosts_empty(self):
+        """
+        Attempting to set empty bootstrap hosts raises an exception. The
+        configured hosts don't change.
+        """
+        c = KafkaClient(hosts=[('kafka.example.com', 1234)])
+        self.assertRaises(Exception, c.update_cluster_hosts, ['foo:notaport'])
+        self.assertEqual(c._bootstrap_hosts, [('kafka.example.com', 1234)])
 
     def test_send_broker_unaware_request_bootstrap_fail(self):
         """
@@ -1688,4 +1704,13 @@ class NormalizeHostsTests(unittest.TestCase):
         self.assertEqual(
             [('kafka1', 1234), ('kafka2', 2345)],
             _normalize_hosts([('kafka2', u'2345'), ('kafka1', b'1234')]),
+        )
+
+    def test_ipv6(self):
+        """
+        IPv6 addresses may be passed as part of a sequence.
+        """
+        self.assertEqual(
+            [('2001:db8::1', 2345), ('::1', 1234)],
+            _normalize_hosts([('2001:db8::1', '2345'), (b'::1', 1234)]),
         )


### PR DESCRIPTION
Accept a sequence of ``(host, port)` tuples when specifying Kafka hosts so that in the common case of already having them in that form the caller needn't coerce to a string. As a side effect, Afkak can accept IPv6 addresses without mangling them.

Fixes #41.