### PR TITLE
attrs updates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,10 @@ Version Next
 * **Feature:**  The string representation of `afkak.Consumer` instances has been cleaned up to make log messages that include it less noisy.
    It now looks like ``<Consumer topicname/0 running>`` where ``0`` is the partition number.
 
-* **Feature:** Additional contextual information has been added to several of `afkak.Consumer` debug log messages.
+* **Feature:** Additional contextual information has been added to several of `afkak.Consumer`'s debug log messages.
+
+* **Bugfix:** Afkak now depends on attrs ≥ 19.2.0 for an [auto_exc bugfix](https://github.com/python-attrs/attrs/issues/543) that affects an exception type internal to `afkak.ConsumerGroup`.
+  Additionally, Afkak's test suite no longer generates `attr.s` deprecation warnings.
 
 Version 19.8.0
 ==============

--- a/afkak/test/endpoints.py
+++ b/afkak/test/endpoints.py
@@ -71,7 +71,7 @@ class _DebugAddress(object):
     port = attr.ib()
 
 
-@attr.s(frozen=True, cmp=False)
+@attr.s(frozen=True, eq=False)
 class Connections(object):
     """Externally controllable endpoint factory
 
@@ -167,12 +167,16 @@ class _PuppetEndpoint(object):
     connect = attr.ib()
 
 
-@attr.s(frozen=True, cmp=False)
+@attr.s(frozen=True, eq=False)
 class KafkaConnection(object):
     """
+    Controller for a connection accepted by `Connections`
     """
+    #: `twisted.test.iosim.FakeTransport` (client mode)
     client = attr.ib()
+    #: `twisted.test.iosim.FakeTransport` (server mode)
     server = attr.ib()
+    #: `twisted.test.iosim.IOPump` that flushes data between *client* and *server*
     pump = attr.ib()
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,9 @@ setup(
     name="afkak",
     version=version,
     install_requires=[
+        'attrs >= 19.2.0',  # For functioning auto_exc=True.
         'six',
-        'Twisted>=18.7.0',  # First release with @inlineCallbacks cancellation
+        'Twisted >= 18.7.0',  # First release with @inlineCallbacks cancellation.
     ],
     # Afkak requires both b'' and u'' syntax, so it isn't compatible with early
     # Python 3 releases. Additionally, Python 3.3 is not supported because


### PR DESCRIPTION
A quick pass to deal with attrs deprecation warnings relating to `cmp`. It turns out that Afkak only uses `cmp` in tests, so this was pretty simple.

There is one use of `auto_exc=True` in production code, so I bumped the attrs dependency just to be safe. I don't think there is any real impact, though.

Closes #108, BPSO-113172.