### PR TITLE
Test Twisted 21.2.0

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["2.7", "3.8"]
+        python-version: ["3.8"]
         kafka-version: ["0.9.0.1", "1.1.1"]
 
     steps:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["2.7", "3.6", "3.7", "3.8", "pypy2", "pypy3"]
+        python-version: ["3.6", "3.7", "3.8", "pypy3"]
 
     steps:
     - uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["2.7", "3.8"]
+        python-version: ["3.8"]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Version 21.2.0
+==============
+
+- **Removal:** Drop support for Python 2.7 and PyPy2, which are no longer supported by Twisted 21.2.0.
+
 Version 20.10.0
 ===============
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 # A tox config file for afkak
 [tox]
 envlist =
-    {py27,py38}-lint,
-    {py27,py35,py36,py37,py38}-{unit,unit-snappy-murmur},
-    {py27,py38}-int-snappy-murmur,
-    {pypy,pypy3}-{unit,unit-snappy}
+    py38-lint,
+    {py35,py36,py37,py38}-{unit,unit-snappy-murmur},
+    {py38}-int-snappy-murmur,
+    pypy3-{unit,unit-snappy}
 
 [testenv]
 setenv =
@@ -33,14 +33,8 @@ deps =
     lint: flake8==3.8.3
     py38-lint: flake8-isort==4.0.0
     py38-lint: flake8-bugbear==20.1.4
-    py27-lint: flake8-commas==2.0.0
+    py38-lint: flake8-commas==2.0.0
     pylint: pylint
-
-    # pyhash 0.9.3 has setup_requires dependencies on these, but easy_install
-    # tries to install Python 3+ versions of them. Avoid this by directing Tox
-    # to install them first.
-    {py27,pypy}-murmur: pytest-runner
-    {py27,pypy}-murmur: pytest-benchmark
 
 commands =
     int: {toxinidir}/tools/download-kafka {env:KAFKA_VERSION}
@@ -111,12 +105,10 @@ include_trailing_comma = true
 
 [gh-actions]
 python =
-    2.7: py27
     3.5: py35
     3.6: py36
     3.7: py37
     3.8: py38
-    pypy2: pypy
     pypy3: pypy3
 
 [gh-actions:env]


### PR DESCRIPTION
- [x] Drop support for Python 2.7 and PyPy2
- [ ] Update package metadata for Python 2.7 drop
- [ ] Remove test dependency on `mock`
- [ ] Test with Twisted 21.2.0rc1
- [ ] Test with Twisted 21.2.0 final

Closes #111 which was never merged for reasons I cannot recall.