### PR TITLE
Add missing test coverage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-Version 21.2.0
+Version 21.4.0
 ==============
 
 - **Removal:** Drop support for Python 2.7 and PyPy2, which are no longer supported by Twisted 21.2.0.

--- a/afkak/test/test_util.py
+++ b/afkak/test/test_util.py
@@ -95,6 +95,60 @@ class TestUtil(unittest.TestCase):
         with self.assertRaises(struct.error):
             util.write_short_bytes(b' ' * 33000)
 
+    def test_write_short_ascii(self):
+        """
+        `write_short_ascii()` accepts a `str` where all characters are in the
+        ASCII range.
+        """
+        self.assertEqual(util.write_short_ascii("ascii"), b"\x00\x05ascii")
+
+    def test_write_short_ascii_not_ascii(self):
+        """
+        `write_short_ascii()` raises `UnicodeEncodeError` when given characters
+        outside the ASCII range.
+        """
+        with self.assertRaises(UnicodeEncodeError):
+            util.write_short_ascii("\N{SNOWMAN}")
+
+    def test_write_short_ascii_nonstr(self):
+        """
+        `write_short_ascii()` raises `TypeError` when passed an argument that
+        isn't a `str`.
+        """
+        self.assertRaises(TypeError, util.write_short_ascii, 1)
+        self.assertRaises(TypeError, util.write_short_ascii, b"ascii")
+
+    def test_write_short_ascii_none(self):
+        """
+        `write_short_ascii()` accepts `None`, which is represented as a special
+        null sequence.
+        """
+        self.assertEqual(util.write_short_ascii(None), b"\xff\xff")
+
+    def test_write_short_text(self):
+        """
+        `write_short_text()` encodes the input string as UTF-8.
+        """
+        self.assertEqual(
+            util.write_short_text("\N{SNOWMAN}"),
+            b"\x00\x03\xe2\x98\x83",
+        )
+
+    def test_write_short_text_nonstr(self):
+        """
+        `write_short_ascii()` raises `TypeError` when passed an argument that
+        isn't a `str`.
+        """
+        self.assertRaises(TypeError, util.write_short_ascii, 1)
+        self.assertRaises(TypeError, util.write_short_ascii, b'bytes')
+
+    def test_write_short_text_none(self):
+        """
+        `write_short_text()` accepts `None`, which is represented as a special
+        null sequence.
+        """
+        self.assertEqual(util.write_short_text(None), b'\xff\xff')
+
     def test_read_short_bytes(self):
         self.assertEqual(
             util.read_short_bytes(b'\xff\xff', 0), (None, 2))

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 # NB: This version is extracted by the Makefile using awk; don't change the
 # formatting here!
-version = "20.10.0"
+version = "21.4.0"
 
 with open('README.md', 'r') as fin:
     readme_lines = fin.readlines()


### PR DESCRIPTION
Add tests of the behavior of `write_short_ascii` and `write_short_text` as mentioned in https://github.com/ciena/afkak/pull/118#discussion_r617040291.