### PR TITLE
Prep release 21.5.0

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.9"]
         kafka-version: ["0.9.0.1", "1.1.1"]
 
     steps:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "pypy3"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "pypy3"]
 
     steps:
     - uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.9"]
 
     steps:
     - uses: actions/checkout@v2
@@ -87,7 +87,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.8"
+        python-version: "3.9"
 
     - name: Install dependencies
       run: |
@@ -107,7 +107,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.8"
+        python-version: "3.9"
 
     - name: Install dependencies
       run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ Version 21.4.0
 
 - **Removal:** Drop support for Python 2.7 and PyPy2, which are no longer supported by Twisted 21.2.0.
 
+- **Bugfix:** `afkak.__version__` didn't match the package metadata. They now align ([#117](https://github.com/ciena/afkak/issues/117)).
+
 Version 20.10.0
 ===============
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 Version 21.4.0
 ==============
 
+- **Feature:** Test with Python 3.9.
+
 - **Removal:** Drop support for Python 2.7 and PyPy2, which are no longer supported by Twisted 21.2.0.
 
 Version 20.10.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-Version 21.4.0
+Version 21.5.0
 ==============
 
 - **Feature:** Test with Python 3.9.

--- a/Makefile
+++ b/Makefile
@@ -15,17 +15,12 @@ KAFKA_RUN := $(SERVERS)/$(KAFKA_VER)/kafka-bin/bin/kafka-run-class.sh
 UNAME := $(shell uname)
 AT ?= @
 
-AFKAK_VERSION := $(shell awk '$$1 == "version" { gsub("\"", "", $$3); print($$3) }' setup.py)
 CHANGES_VERSION := $(shell awk 'NR == 1 { print($$2); }' CHANGES.md)
 INIT_VERSION := $(shell awk '$$1 == "__version__" { gsub("\"", "", $$3); print($$3) }' afkak/__init__.py)
-ifneq ($(AFKAK_VERSION),$(CHANGES_VERSION))
-  ifneq ($(AFKAK_VERSION)-SNAPSHOT,$(CHANGES_VERSION))
-    $(error Version on first line of CHANGES.md ($(CHANGES_VERSION)) does not match the version in setup.py ($(AFKAK_VERSION)))
+ifneq ($(INIT_VERSION),$(CHANGES_VERSION))
+  ifneq ($(INIT_VERSION)-SNAPSHOT,$(CHANGES_VERSION))
+    $(error Version on first line of CHANGES.md ($(CHANGES_VERSION)) does not match the version in setup.py ($(INIT_VERSION)))
   endif
-endif
-
-ifneq ($(INIT_VERSION),$(AFKAK_VERSION))
-  $(error Version in setup.py ($(AFKAK_VERSION)) does not match afkak/__init__.py ($(INIT_VERSION)))
 endif
 
 ifeq ($(UNAME),Darwin)

--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@
 <a href="https://calver.org/"><img src="https://img.shields.io/badge/calver-YY.MM.MICRO-22bfda.svg" alt="calver: YY.MM.MICRO"></a>
 <a href="./LICENSE"><img src="https://img.shields.io/pypi/l/afkak.svg" alt="Apache 2.0"></a>
 <a href="https://afkak.readthedocs.io/en/latest/"><img src="https://readthedocs.org/projects/pip/badge/" alt="Documentation"></a>
-<!--
-TODO: Uncomment this once the build is less flaky.
-<a href="https://travis-ci.org/ciena/afkak"><img src="https://travis-ci.org/ciena/afkak.svg?branch=master" alt="Travis CI"></a>
--->
 
 <!--
 Everything between the LONG_DESCRIPTION_START and LONG_DESCRIPTION_END
@@ -29,9 +25,8 @@ Please report any issues [on GitHub](https://github.com/ciena/afkak/issues).
 
 Afkak supports these Pythons:
 
-- CPython 2.7
-- CPython 3.5, 3.6, 3.7, and 3.8
-- PyPy and PyPy3 6.0+
+- CPython 3.5, 3.6, 3.7, 3.8, and 3.9
+- PyPy3
 
 We aim to support Kafka 1.1.<var>x</var> and later.
 Integration tests are run against these Kafka broker versions:
@@ -43,7 +38,7 @@ Testing against 2.0.0 is planned (see [#45](https://github.com/ciena/afkak/issue
 
 Newer broker releases will generally function, but not all Afkak features will work on older brokers.
 In particular, the coordinated consumer won’t work before Kafka 0.9.0.1.
-We don’t recommend deploying such old releases anyway, as they have serious bugs.
+We don’t recommend deploying such old releases of Kafka anyway, as they have serious bugs.
 
 # Usage
 
@@ -171,7 +166,7 @@ Because the Afkak dependencies [Twisted][twisted] and [python-snappy][python-sna
 <table>
 <tr>
 <td>Debian/Ubuntu:
-<td><code>sudo apt-get install build-essential python-dev python3-dev pypy-dev pypy3-dev libsnappy-dev</code>
+<td><code>sudo apt-get install build-essential python3-dev pypy3-dev libsnappy-dev</code>
 <tr>
 <td>OS X
 <td><code>brew install python pypy snappy</code></br>
@@ -188,7 +183,7 @@ Copyright 2013, 2014, 2015 David Arthur under Apache License, v2.0. See `LICENSE
 
 Copyright 2014, 2015 Cyan, Inc. under Apache License, v2.0. See `LICENSE`
 
-Copyright 2015, 2016, 2017, 2018, 2019 Ciena Corporation under Apache License, v2.0. See `LICENSE`
+Copyright 2015–2021 Ciena Corporation under Apache License, v2.0. See `LICENSE`
 
 This project began as a port of the [kafka-python][kafka-python] library to Twisted.
 
@@ -234,11 +229,11 @@ Alternatively, you might want to run unit tests in a list of specific
 Python versions:
 
 ```shell
-.env/bin/tox -e py27-unit-snappy,py35-unit-snappy
+.env/bin/tox -e py35-unit-snappy,py38-unit-snappy
 ```
 
-It is recommended for contributors to run unit tests in at least Python 2.7 and
-one Python 3 version before submitting a pull request.
+Please run the tests on the minimum and maximum supported Python versions
+before submitting a pull request.
 
 ### Run the integration tests
 

--- a/afkak/__init__.py
+++ b/afkak/__init__.py
@@ -14,7 +14,7 @@ from .partitioner import HashedPartitioner, RoundRobinPartitioner
 from .producer import Producer
 
 __title__ = 'afkak'
-__version__ = "21.4.0"  # setuptools parses this. Retain formatting.
+__version__ = "21.5.0"  # setuptools parses this. Retain formatting.
 __author__ = "Robert Thille"
 __license__ = 'Apache License 2.0'
 

--- a/afkak/__init__.py
+++ b/afkak/__init__.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 Cyan, Inc.
-# Copyright 2018, 2019, 2020 Ciena Corporation
-
-from __future__ import absolute_import
+# Copyright 2018, 2019, 2020, 2021 Ciena Corporation
 
 from ._group import ConsumerGroup
 from .client import KafkaClient
@@ -15,10 +13,9 @@ from .kafkacodec import create_message, create_message_set
 from .partitioner import HashedPartitioner, RoundRobinPartitioner
 from .producer import Producer
 
-# Note, you need to bump the version in setup.py as well
 __title__ = 'afkak'
-__version__ = "20.9.0"  # Makefile parses this. Retain formatting.
-__author__ = 'Robert Thille'
+__version__ = "21.4.0"  # setuptools parses this. Retain formatting.
+__author__ = "Robert Thille"
 __license__ = 'Apache License 2.0'
 
 __all__ = [

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,8 +12,8 @@ It provides support for:
 
 Afkak |release| was tested against:
 
-:Python: CPython 2.7, 3.5+; PyPy, PyPy3 6.0+
-:Twisted: 18.9.0
+:Python: CPython 3.5+; PyPy3
+:Twisted: 21.2.0
 :Kafka: 0.9.0.1, 1.1.1
 
 Newer broker releases will generally function, but not all Afkak features will work on older brokers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 46.4.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[metadata]
+version = attr: afkak.__version__
+author = attr: afkak.__author__
+author_email = rthille@ciena.com
+maintainer = Tom Most
+maintainer_email = twm@freecog.net

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,6 @@
 
 from setuptools import find_packages, setup
 
-# NB: This version is extracted by the Makefile using awk; don't change the
-# formatting here!
-version = "21.4.0"
-
 with open('README.md', 'r') as fin:
     readme_lines = fin.readlines()
 long_description = ''.join(readme_lines[
@@ -17,7 +13,6 @@ long_description = ''.join(readme_lines[
 
 setup(
     name="afkak",
-    version=version,
     install_requires=[
         'attrs >= 19.2.0',  # For functioning auto_exc=True.
         'Twisted >= 18.7.0',  # First release with @inlineCallbacks cancellation.
@@ -37,10 +32,6 @@ setup(
 
     zip_safe=True,
 
-    author="Robert Thille",
-    author_email="rthille@ciena.com",
-    maintainer="Tom Most",
-    maintainer_email="twm@freecog.net",
     url="https://github.com/ciena/afkak",
     project_urls={
         'Documentation': 'https://afkak.readthedocs.io/en/latest/',

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@
 minversion = 3.3.0
 isolated_build = true
 envlist =
-    py38-lint,
-    {py35,py36,py37,py38}-{unit,unit-snappy-murmur},
-    py38-int-snappy-murmur,
+    py39-lint,
+    {py35,py36,py37,py38,py39}-{unit,unit-snappy-murmur},
+    py39-int-snappy-murmur,
     pypy3-{unit,unit-snappy}
 
 [testenv]
@@ -32,9 +32,9 @@ deps =
     coverage==4.0.1
     Twisted==21.2.0
     lint: flake8==3.8.3
-    py38-lint: flake8-isort==4.0.0
-    py38-lint: flake8-bugbear==20.1.4
-    py38-lint: flake8-commas==2.0.0
+    py39-lint: flake8-isort==4.0.0
+    py39-lint: flake8-bugbear==20.1.4
+    py39-lint: flake8-commas==2.0.0
     pylint: pylint
 
 commands =
@@ -70,7 +70,7 @@ commands =
     coverage html -d {toxinidir}/htmlcov
 
 [testenv:docs]
-basepython = python3.8
+basepython = python3.9
 deps =
     Sphinx~=1.8.3
 changedir = docs
@@ -79,7 +79,7 @@ commands =
     sphinx-build -b html -d {envtmpdir}/doctrees . html
 
 [testenv:twine]
-basepython = python3.8
+basepython = python3.9
 deps =
     twine
     readme_renderer[md]
@@ -110,6 +110,7 @@ python =
     3.6: py36
     3.7: py37
     3.8: py38
+    3.9: py39
     pypy3: pypy3
 
 [gh-actions:env]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 # A tox config file for afkak
 [tox]
+minversion = 3.3.0
+isolated_build = true
 envlist =
     py38-lint,
     {py35,py36,py37,py38}-{unit,unit-snappy-murmur},


### PR DESCRIPTION
- [x] Don't generate universal (py2 + py3) wheels, as we no longer support Python 2.7.
- [x] Correct discrepancies in the package version
- [x] Test on Python 3.9

Closes #117.