### PR TITLE
BPSO-120796- Afkak tests able to run on Github (WIP)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
-        kafka-version: ["0.9.0.1", "1.1.1"]
+        kafka-version: ["1.1.1"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "pypy3"]
+        python-version: ["3.7", "3.8", "3.9", "pypy3"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -23,6 +23,7 @@ jobs:
     - name: Install build dependencies
       run: |
         sudo apt-get install -yqq build-essential libsnappy-dev
+        sudo apt-get -y install python3-distutils-extra
 
     - name: "Set up Python ${{ matrix.python-version }}"
       uses: actions/setup-python@v2

--- a/afkak/test/int/test_group_integration.py
+++ b/afkak/test/int/test_group_integration.py
@@ -505,7 +505,8 @@ class TestAfkakGroupIntegration(IntegrationMixin, unittest.TestCase):
             [value] = yield self.send_messages(part, ['sentinel'])
             pending_sentinels[part] = value
         while pending_sentinels:
-            [message] = yield record_stream.get()
+            # [message] = yield record_stream.get()
+            *message = yield record_stream.get()
             if pending_sentinels.get(message.partition) == message.message.value:
                 del pending_sentinels[message.partition]
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     # versions.
     python_requires='!=3.0.*, !=3.1.*, !=3.2.*, <4',
     extras_require={
-        'FastMurmur2': ['pyhash'],
+        'FastMurmur2': ['pyhash@git+https://github.com/mvaught02/pyfasthash@py39-update'],
         'snappy': ['python-snappy>=0.5'],
     },
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ minversion = 3.3.0
 isolated_build = true
 envlist =
     py39-lint,
-    {py35,py36,py37,py38,py39}-{unit,unit-snappy-murmur},
+    {py37,py38,py39}-{unit,unit-snappy-murmur},
     py39-int-snappy-murmur,
     pypy3-{unit,unit-snappy}
 
@@ -106,8 +106,8 @@ include_trailing_comma = true
 
 [gh-actions]
 python =
-    3.5: py35
-    3.6: py36
+    # 3.5: py35
+    # 3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
BPSO-120796- Afkak tests able to run on Github (WIP)
tox.ini - Updated tox.ini for python 37,38 and 39
test_group_integration.py - Updated the consuming messages from the stream
setup.py - updated the FastMurmur2 change(temp)
unit.yml - Updated to install the distutil package for py37. 
