### PR TITLE
add support to retrieve protocol version [KIP-35]

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   integration-tests:
     name: "Python ${{ matrix.python-version }} + Kafka ${{ matrix.kafka-version }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       TOX_SUITE: int
       KAFKA_VERSION: "${{ matrix.kafka-version }}"

--- a/afkak/_group.py
+++ b/afkak/_group.py
@@ -658,7 +658,7 @@ class _ConsumerProtocol(object):
         try:
             all_topic_partitions = [(topic, partition) for topic in all_topics for partition in topic_partitions[topic]]
         except KeyError:
-            raise _NeedTopicPartitions(all_topics)
+            raise _NeedTopicPartitions(all_topics) from None
 
         all_topic_partitions.sort()
 

--- a/afkak/client.py
+++ b/afkak/client.py
@@ -30,6 +30,7 @@ from ._util import _coerce_client_id, _coerce_consumer_group, _coerce_topic
 from .brokerclient import _KafkaBrokerClient
 from .common import (
     ApiVersionRequest,
+    ApiVersionResponse,
     BrokerMetadata,
     BrokerResponseError,
     CancelledError,
@@ -782,15 +783,10 @@ class KafkaClient(object):
     # # # Private Methods # # #
 
     @defer.inlineCallbacks
-    def _get_api_versions(self):
+    def _get_api_versions(self) -> ApiVersionResponse:
         """
         Get the API versions supported by the given broker.
 
-        Args:
-            broker (BrokerMetadata): broker to query
-
-        Returns:
-            dict: API versions supported by the broker
         """
         requestId = self._next_id()
 

--- a/afkak/common.py
+++ b/afkak/common.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import namedtuple
 from typing import List
 
 import attr

--- a/afkak/common.py
+++ b/afkak/common.py
@@ -79,36 +79,40 @@ class BaseStruct:
 @attr.frozen
 class SendRequest(BaseStruct):
     """
-    Request to send a message to a topic
+    Represents a request to send a message to a Kafka topic.
 
-    Attributes:
-        topic (str): The topic this request is for
-        key (bytes): The key for the message
-        messages (List[bytes]): The messages to include in the request
-        deferred (Deferred): The deferred to fire when the request is complete
+    :ivar str topic: The name of the topic.
+    :ivar bytes, optional key: The key to include in the request. Defaults to None.
+    :ivar List[bytes], optional messages: The messages to include in the request. Defaults to None.
+    :ivar Deferred, optional deferred: The `Deferred` object to fire when the request is complete. Defaults to None.
+
+    :note: The `key` and `messages` fields are optional and can be None if no messages need to be sent. If messages
+        are included, they should be bytes objects representing the message payload.
     """
 
-    topic: str = attr.field()
-    key: bytes = attr.field(default=None)
-    messages: list = attr.field(default=None)
-    deferred: Deferred = attr.field(default=None)
+    topic: str = attr.ib()
+    key: bytes = attr.ib(default=None)
+    messages: list = attr.ib(default=None)
+    deferred: Deferred = attr.ib(default=None)
 
 
 # Request payloads
 @attr.frozen
 class ProduceRequest(BaseStruct):
     """
-    Request to produce a message to a topic/partition
+    Represents a request to produce one or more messages to a Kafka topic and partition.
 
-    Attributes:
-        topic (str): The topic this request is for
-        partition (int): The partition this request is for
-        messages (List[bytes]): The messages to include in the request
+    :ivar str topic: The name of the topic.
+    :ivar int partition: The partition to produce to.
+    :ivar List[bytes], optional messages: The messages to include in the request. Defaults to None.
+
+    :note: The `messages` field is optional and can be an empty list if no messages need to be produced. If messages
+        are included, they should be bytes objects representing the message payload.
     """
 
-    topic: str = attr.field()
-    partition: int = attr.field()
-    messages: List[bytes] = attr.field(default=None)
+    topic: str = attr.ib()
+    partition: int = attr.ib()
+    messages: List[bytes] = attr.ib(default=None)
 
 
 # Request payloads
@@ -119,17 +123,18 @@ class FetchRequest(BaseStruct):
     """
     Request to fetch a set of messages from a topic/partition
 
-    Attributes:
-        topic (str): The topic this request is for
-        partition (int): The partition this request is for
-        offset (int): The offset to begin this fetch from
-        max_bytes (int): The maximum bytes to include in the message set for this partition
+    :ivar str topic: The topic this request is for
+    :ivar int partition: The partition this request is for
+    :ivar int offset: The offset to use for this request
+    :ivar int max_bytes: The maximum number of bytes to include in the response
+
+    :note: The `max_bytes` field is optional and can be None if no messages need to be fetched.
     """
 
-    topic: str = attr.field()
-    partition: int = attr.field()
-    offset: int = attr.field()
-    max_bytes: int = attr.field(default=None)
+    topic: str = attr.ib()
+    partition: int = attr.ib()
+    offset: int = attr.ib()
+    max_bytes: int = attr.ib(default=None)
 
 
 @attr.frozen
@@ -137,17 +142,18 @@ class OffsetRequest(BaseStruct):
     """
     Request to fetch the last committed offset for a set of partitions
 
-    Attributes:
-        topic (str): The topic this request is for
-        partition (int): The partition this request is for
-        time (int): The time to use for fetching offsets
-        max_offsets (int): The maximum number of offsets to return
+    :ivar str topic: The topic this request is for
+    :ivar int partition: The partition this request is for
+    :ivar int time: Time to use for fetching offsets. Specify -1 to receive the latest offsets and -2 to receive the earliest available offsets. Defaults to -1.
+    :ivar int max_offsets: Maximum number of offsets to return. Defaults to 1.
+
+    :note: The `time` and `max_offsets` fields are optional and can be None if no messages need to be fetched.
     """
 
-    topic: str = attr.field()
-    partition: int = attr.field()
-    time: int = attr.field(default=None)
-    max_offsets: int = attr.field(default=None)
+    topic: str = attr.ib()
+    partition: int = attr.ib()
+    time: int = attr.ib(default=-1)
+    max_offsets: int = attr.ib(default=1)
 
 
 @attr.frozen
@@ -155,20 +161,20 @@ class OffsetCommitRequest(BaseStruct):
     """
     Request to commit a specific offset for a topic/partition
 
-    Attributes:
-        topic (str): The topic this request is for
-        partition (int): The partition this request is for
-        offset (int): The offset to commit
-        timestamp (int): The timestamp of the commit
-        metadata (bytes): Any associated metadata the client wants to keep
+    :ivar str topic: The topic this request is for
+    :ivar int partition: The partition this request is for
+    :ivar int offset: The offset to commit
+    :ivar int timestamp: The timestamp of the commit
+    :ivar bytes metadata: Any associated metadata the client wants to keep
 
+    :note: The `timestamp` and `metadata` fields are optional and can be None if no messages need to be fetched.
     """
 
-    topic: str = attr.field()
-    partition: int = attr.field()
-    offset: int = attr.field()
-    timestamp: int = attr.field(default=None)
-    metadata: bytes = attr.field(default=None)
+    topic: str = attr.ib()
+    partition: int = attr.ib()
+    offset: int = attr.ib()
+    timestamp: int = attr.ib(default=None)
+    metadata: bytes = attr.ib(default=None)
 
 
 @attr.frozen
@@ -176,14 +182,12 @@ class OffsetFetchRequest(BaseStruct):
     """
     Request to fetch the last committed offset for a set of partitions
 
-    Attributes:
-        topic (str): The topic this request is for
-        partition (int): The partition this request is for
-
+    :ivar str topic: The topic this request is for
+    :ivar int partition: The partition this request is for
     """
 
-    topic: str = attr.field()
-    partition: int = attr.field()
+    topic: str = attr.ib()
+    partition: int = attr.ib()
 
 
 # Response payloads
@@ -192,18 +196,16 @@ class ProduceResponse(BaseStruct):
     """
     Response from a ProduceRequest
 
-    Attributes:
-        topic (str): The topic this response entry is for
-        partition (int): The partition this response entry is for
-        error (int): The error code for this request
-        offset (int): The offset of the message that was produced
-
+    :ivar str topic: The topic this response entry is for
+    :ivar int partition: The partition this response entry is for
+    :ivar int error: The error code for this request
+    :ivar int offset: The offset of the message in the partition
     """
 
-    topic: str = attr.field()
-    partition: int = attr.field()
-    error: int = attr.field()
-    offset: int = attr.field()
+    topic: str = attr.ib()
+    partition: int = attr.ib()
+    error: int = attr.ib()
+    offset: int = attr.ib()
 
 
 @attr.frozen
@@ -211,20 +213,19 @@ class FetchResponse(BaseStruct):
     """
     Response from a FetchRequest
 
-    Attributes:
-        topic (str): The topic this response entry is for
-        partition (int): The partition this response entry is for
-        error (int): The error code for this request
-        highwaterMark (int): The offset of the last message in the partition
-        messages (list): The messages returned by the request
+    :ivar str topic: The topic this response entry is for
+    :ivar int partition: The partition this response entry is for
+    :ivar int error: The error code for this request
+    :ivar int highwaterMark: The offset of the last message in the partition
+    :ivar List[Message]: The messages returned by the request
 
     """
 
-    topic: str = attr.field()
-    partition: int = attr.field()
-    error: int = attr.field()
-    highwaterMark: int = attr.field()
-    messages: list = attr.field()
+    topic: str = attr.ib()
+    partition: int = attr.ib()
+    error: int = attr.ib()
+    highwaterMark: int = attr.ib()
+    messages: List['Message'] = attr.ib()
 
 
 @attr.frozen
@@ -232,18 +233,16 @@ class OffsetResponse(BaseStruct):
     """
     Response from an OffsetRequest
 
-    Attributes:
-        topic (str): The topic this response entry is for
-        partition (int): The partition this response entry is for
-        error (int): The error code for this request
-        offsets (list): The offsets returned by the request
-
+    :ivar str topic: The topic this response entry is for
+    :ivar int partition: The partition this response entry is for
+    :ivar int error: The error code for this request
+    :ivar List[int] offsets: The offsets returned by the request
     """
 
-    topic: str = attr.field()
-    partition: int = attr.field()
-    error: int = attr.field()
-    offsets: list = attr.field()
+    topic: str = attr.ib()
+    partition: int = attr.ib()
+    error: int = attr.ib()
+    offsets: List[int] = attr.ib()
 
 
 @attr.frozen
@@ -251,16 +250,14 @@ class OffsetCommitResponse(BaseStruct):
     """
     Response from an OffsetCommitRequest
 
-    Attributes:
-        topic (str): The topic this response entry is for
-        partition (int): The partition this response entry is for
-        error (int): The error code for this request
-
+    :ivar str topic: The topic this response entry is for
+    :ivar int partition: The partition this response entry is for
+    :ivar int error: The error code for this request
     """
 
-    topic: str = attr.field()
-    partition: int = attr.field()
-    error: int = attr.field()
+    topic: str = attr.ib()
+    partition: int = attr.ib()
+    error: int = attr.ib()
 
 
 @attr.frozen
@@ -268,20 +265,18 @@ class OffsetFetchResponse(BaseStruct):
     """
     Response from an OffsetFetchRequest
 
-    Attributes:
-        topic (str): The topic this response entry is for
-        partition (int): The partition this response entry is for
-        offset (int): The offset for this partition
-        metadata (bytes): Any associated metadata the server has for this partition
-        error (int): The error code for this request
-
+    :ivar str topic: The topic this response entry is for
+    :ivar int partition: The partition this response entry is for
+    :ivar int offset: The offset returned by the request
+    :ivar bytes metadata: The metadata returned by the request
+    :ivar int error: The error code for this request
     """
 
-    topic: str = attr.field()
-    partition: int = attr.field()
-    offset: int = attr.field()
-    metadata: bytes = attr.field()
-    error: int = attr.field()
+    topic: str = attr.ib()
+    partition: int = attr.ib()
+    offset: int = attr.ib()
+    metadata: bytes = attr.ib()
+    error: int = attr.ib()
 
 
 @attr.frozen
@@ -289,18 +284,17 @@ class ConsumerMetadataResponse(BaseStruct):
     """
     Response from a ConsumerMetadataRequest
 
-    Attributes:
-        error (int): The error code for this request
-        node_id (int): The node id for the coordinator
-        host (str): The hostname of the coordinator
-        port (int): The port for the coordinator
+    :ivar int error: The error code for this request
+    :ivar int node_id: The node id for the coordinator
+    :ivar str host: The hostname of the coordinator
+    :ivar int port: The port for the coordinator
 
     """
 
-    error: int = attr.field()
-    node_id: int = attr.field()
-    host: str = attr.field()
-    port: int = attr.field()
+    error: int = attr.ib()
+    node_id: int = attr.ib()
+    host: str = attr.ib()
+    port: int = attr.ib()
 
 
 # Metadata tuples
@@ -309,16 +303,14 @@ class BrokerMetadata(BaseStruct):
     """
     Metadata for a single broker
 
-    Attributes:
-        node_id (int): The node id for this broker
-        host (str): The hostname of this broker
-        port (int): The port for this broker
-
+    :ivar int node_id: The node id for this broker
+    :ivar str host: The hostname of this broker
+    :ivar int port: The port for this broker
     """
 
-    node_id: int = attr.field()
-    host: str = attr.field()
-    port: int = attr.field()
+    node_id: int = attr.ib()
+    host: str = attr.ib()
+    port: int = attr.ib()
 
 
 @attr.frozen
@@ -326,16 +318,15 @@ class TopicMetadata(BaseStruct):
     """
     Metadata for a single topic
 
-    Attributes:
-        topic (str): The topic name
-        topic_error_code (int): The error code for this topic
-        partition_metadata (list): The set of all partitions for this topic
+    :ivar str topic: The topic name
+    :ivar int topic_error_code: The error code for this topic
+    :ivar List[PartitionMetadata] partition_metadata: The set of partitions for this topic
 
     """
 
-    topic: str = attr.field()
-    topic_error_code: int = attr.field()
-    partition_metadata: List[bytes] = attr.field()
+    topic: str = attr.ib()
+    topic_error_code: int = attr.ib()
+    partition_metadata: List[bytes] = attr.ib()
 
 
 @attr.frozen
@@ -343,22 +334,20 @@ class PartitionMetadata(BaseStruct):
     """
     Metadata for a single partition
 
-    Attributes:
-        topic (str): The topic name
-        partition (int): The partition id
-        partition_error_code (int): The error code for this partition
-        leader (int): The node id for the leader
-        replicas (list): The set of all nodes that host this partition
-        isr (list): The set of nodes that are in sync with the leader for this partition
-
+    :ivar str topic: The topic name
+    :ivar int partition: The partition id
+    :ivar int partition_error_code: The error code for this partition
+    :ivar int leader: The node id for the leader of this partition
+    :ivar List[int] replicas: The set of replica nodes for this partition
+    :ivar List[int] isr: The set of in-sync replica nodes for this partition
     """
 
-    topic: str = attr.field()
-    partition: int = attr.field()
-    partition_error_code: int = attr.field()
-    leader: int = attr.field()
-    replicas: list = attr.field()
-    isr: list = attr.field()
+    topic: str = attr.ib()
+    partition: int = attr.ib()
+    partition_error_code: int = attr.ib()
+    leader: int = attr.ib()
+    replicas: list = attr.ib()
+    isr: list = attr.ib()
 
 
 # ApiVersionRequest and ApiVersionResponse
@@ -367,14 +356,12 @@ class ApiVersionRequest(BaseStruct):
     """
     Request to discover supported API versions
 
-    Attributes:
-        api_key (int): The API key
-        api_version (int): The API version
-
+    :ivar int api_key: The API key to use
+    :ivar int api_version: The API version to use
     """
 
-    api_key: int = attr.field()
-    api_version: int = attr.field()
+    api_key: int = attr.ib()
+    api_version: int = attr.ib()
 
 
 @attr.frozen
@@ -382,14 +369,12 @@ class ApiVersionResponse(BaseStruct):
     """
     Response from an ApiVersionRequest
 
-    Attributes:
-        error_code (int): Response error code
-        api_versions (list): List of supported API versions
-
+    :ivar int error_code: The error code for this request
+    :ivar List[ApiVersion] api_versions: The supported API versions
     """
 
-    error_code: int = attr.field()
-    api_versions: list = attr.field()
+    error_code: int = attr.ib()
+    api_versions: list = attr.ib()
 
 
 # Requests and responses for consumer groups
@@ -398,9 +383,8 @@ class _JoinGroupRequestProtocol(object):
     """
     A protocol that the consumer supports.
 
-    Attributes:
-        protocol_name (str): The name of the protocol
-        protocol_metadata (bytes): The encoded metadata for the protocol
+    :ivar str protocol_name: The name of the protocol
+    :ivar bytes protocol_metadata: Any additional metadata that the consumer wants to send to the group coordinator
     """
 
     protocol_name = attr.ib()
@@ -412,10 +396,9 @@ class _JoinGroupProtocolMetadata(object):
     """
     The metadata for a protocol that the consumer supports.
 
-    Attributes:
-        version (int): The version of the protocol
-        subscriptions (list): The list of topics that the consumer wants to subscribe to
-        user_data (bytes): Any additional data that the consumer wants to send to the group coordinator
+    :ivar str version: The version of the protocol
+    :ivar List[_JoinGroupRequestProtocol] subscriptions: The list of protocols that the consumer supports
+    :ivar bytes user_data: Any additional metadata that the consumer wants to send to the group coordinator
     """
 
     version = attr.ib()
@@ -428,14 +411,13 @@ class _JoinGroupRequest(object):
     """
     A request to join a coordinator group.
 
-    Attributes:
-        group (str): The name of the group to join
-        session_timeout (int): The time in milliseconds that the coordinator will wait for the consumer to send a
-            JoinGroupResponse
-        member_id (str): The unique identifier for the consumer. This is generated by the consumer and should be
-            unique across all consumers.
-        protocol_type (str): The type of protocol that the consumer supports
-        group_protocols (list): The list of protocols that the consumer supports
+    :ivar str group: The name of the group to join
+    :ivar int session_timeout: The time in milliseconds that the coordinator will wait for the consumer to send a
+        JoinGroupResponse
+    :ivar str member_id: The unique identifier for the consumer. This is generated by the consumer and should be
+        unique across all consumers.
+    :ivar str protocol_type: The unique name for class of protocols implemented by the consumer
+    :ivar List[_JoinGroupProtocolMetadata] group_protocols: The list of protocols that the consumer supports
     """
 
     group = attr.ib()
@@ -450,10 +432,9 @@ class _JoinGroupResponseMember(object):
     """
     A member of a consumer group.
 
-    Attributes:
-        member_id (str): The unique identifier for the consumer. This is generated by the consumer and should be
-            unique across all consumers.
-        member_metadata (bytes): The encoded metadata for the consumer
+    :ivar str member_id: The unique identifier for the consumer. This is generated by the consumer and should be
+        unique across all consumers.
+    :ivar bytes member_metadata: Any additional metadata that the consumer wants to send to the group coordinator
     """
 
     member_id = attr.ib()
@@ -465,14 +446,13 @@ class _JoinGroupResponse(object):
     """
     A response from a coordinator group.
 
-    Attributes:
-        error (int): The error code for the request
-        generation_id (int): The generation id for the consumer group
-        group_protocol (str): The protocol that the group coordinator selected
-        leader_id (str): The unique identifier for the leader of the consumer group
-        member_id (str): The unique identifier for the consumer. This is generated by the consumer and should be
-            unique across all consumers.
-        members (list): The list of members in the consumer group
+    :ivar int error: The error code for the request
+    :ivar str generation_id: The unique identifier for the consumer group
+    :ivar str group_protocol: The unique name for class of protocols implemented by the consumer
+    :ivar str leader_id: The unique identifier for the consumer that is the leader of the group
+    :ivar str member_id: The unique identifier for the consumer. This is generated by the consumer and should be
+        unique across all consumers.
+    :ivar List[_JoinGroupResponseMember] members: The list of members in the group
     """
 
     error = attr.ib()
@@ -488,10 +468,9 @@ class _SyncGroupRequestMember(object):
     """
     A member of a consumer group.
 
-    Attributes:
-        member_id (str): The unique identifier for the consumer. This is generated by the consumer and should be
-            unique across all consumers.
-        member_metadata (bytes): The encoded metadata for the consumer
+    :ivar str member_id: The unique identifier for the consumer. This is generated by the consumer and should be
+        unique across all consumers.
+    :ivar bytes member_metadata: Any additional metadata that the consumer wants to send to the group coordinator
     """
 
     member_id = attr.ib()
@@ -503,10 +482,9 @@ class _SyncGroupMemberAssignment(object):
     """
     The assignment for a member of a consumer group.
 
-    Attributes:
-        version (int): The version of the assignment
-        assignments (list): The list of partitions that the consumer is assigned to
-        user_data (bytes): Any additional data that the consumer wants to send to the group coordinator
+    :ivar str version: The version of the protocol
+    :ivar bytes assignments: The assignment for the member
+    :ivar bytes user_data: Any additional metadata that the consumer wants to send to the group coordinator
     """
 
     version = attr.ib()
@@ -519,12 +497,11 @@ class _SyncGroupRequest(object):
     """
     A request to sync with a consumer group.
 
-    Attributes:
-        group (str): The name of the group to sync with
-        generation_id (int): The generation id for the consumer group
-        member_id (str): The unique identifier for the consumer. This is generated by the consumer and should be
-            unique across all consumers.
-        group_assignment (dict): The assignment for each member of the consumer group
+    :ivar str group: The name of the group to sync with
+    :ivar int generation_id: The generation id for the consumer group
+    :ivar str member_id: The unique identifier for the consumer. This is generated by the consumer and should be
+        unique across all consumers.
+    :ivar List[_SyncGroupRequestMember] group_assignment: The list of members in the group
     """
 
     group = attr.ib()
@@ -538,9 +515,8 @@ class _SyncGroupResponse(object):
     """
     A response from a consumer group sync.
 
-    Attributes:
-        error (int): The error code for the request
-        member_assignment (bytes): The encoded assignment for the consumer
+    :ivar int error: The error code for the request
+    :ivar bytes member_assignment: The assignment for the member
     """
 
     error = attr.ib()
@@ -552,11 +528,10 @@ class _HeartbeatRequest(BaseStruct):
     """
     A request to send a heartbeat to a consumer group coordinator.
 
-    Attributes:
-        group (str): The name of the group to send a heartbeat to
-        generation_id (int): The generation id for the consumer group
-        member_id (str): The unique identifier for the consumer. This is generated by the consumer and should be
-            unique across all consumers.
+    :ivar str group: The name of the group to send the heartbeat to
+    :ivar int generation_id: The generation id for the consumer group
+    :ivar str member_id: The unique identifier for the consumer. This is generated by the consumer and should be
+        unique across all consumers.
     """
 
     group = attr.ib()
@@ -569,8 +544,7 @@ class _HeartbeatResponse(BaseStruct):
     """
     A response from a consumer group heartbeat.
 
-    Attributes:
-        error (int): The error code for the request
+    :ivar int error: The error code for the request
     """
 
     error = attr.ib()
@@ -581,10 +555,9 @@ class _LeaveGroupRequest(BaseStruct):
     """
     A request to leave a consumer group.
 
-    Attributes:
-        group (str): The name of the group to leave
-        member_id (str): The unique identifier for the consumer. This is generated by the consumer and should be
-            unique across all consumers.
+    :ivar str group: The name of the group to leave
+    :ivar str member_id: The unique identifier for the consumer. This is generated by the consumer and should be
+        unique across all consumers.
     """
 
     group = attr.ib()
@@ -596,8 +569,7 @@ class _LeaveGroupResponse(BaseStruct):
     """
     A response from a consumer group leave.
 
-    Attributes:
-        error (int): The error code for the request
+    :ivar int error: The error code for the request
     """
 
     error = attr.ib()
@@ -609,9 +581,8 @@ class OffsetAndMessage(BaseStruct):
     """
     A message with an associated offset.
 
-    Attributes:
-        offset (int): The offset of the message
-        message (kafka.protocol.message.Message): The message
+    :ivar int offset: The offset of the message
+    :ivar kafka.protocol.message.Message message: The message
     """
 
     offset = attr.ib()
@@ -623,9 +594,8 @@ class TopicAndPartition(BaseStruct):
     """
     A topic and partition.
 
-    Attributes:
-        topic (str): The name of the topic
-        partition (int): The partition id
+    :ivar str topic: The name of the topic
+    :ivar int partition: The partition id
     """
 
     topic = attr.ib()
@@ -637,11 +607,8 @@ class SourcedMessage(BaseStruct):
     """
     A message with an associated offset, topic, and partition.
 
-    Attributes:
-        topic (str): The name of the topic
-        partition (int): The partition id
-        offset (int): The offset of the message
-        message (kafka.protocol.message.Message): The message
+    :ivar str topic: The name of the topic
+    :ivar int partition: The partition id
     """
 
     topic = attr.ib()
@@ -666,10 +633,10 @@ class Message(BaseStruct):
     .. _message: https://kafka.apache.org/documentation/#messageset
     """
 
-    magic = attr.field()
-    attributes = attr.field()
-    key = attr.field()
-    value = attr.field()
+    magic = attr.ib()
+    attributes = attr.ib()
+    key = attr.ib()
+    value = attr.ib()
 
     def __repr__(self):
         bits = ["<Message v0"]

--- a/afkak/common.py
+++ b/afkak/common.py
@@ -144,7 +144,8 @@ class OffsetRequest(BaseStruct):
 
     :ivar str topic: The topic this request is for
     :ivar int partition: The partition this request is for
-    :ivar int time: Time to use for fetching offsets. Specify -1 to receive the latest offsets and -2 to receive the earliest available offsets. Defaults to -1.
+    :ivar int time: Time to use for fetching offsets. Specify -1 to receive the latest offsets and -2 to receive
+        the earliest available offsets. Defaults to -1.
     :ivar int max_offsets: Maximum number of offsets to return. Defaults to 1.
 
     :note: The `time` and `max_offsets` fields are optional and can be None if no messages need to be fetched.

--- a/afkak/common.py
+++ b/afkak/common.py
@@ -202,6 +202,19 @@ class PartitionMetadata(BaseStruct):
     isr: list = attr.field()
 
 
+# ApiVersionRequest and ApiVersionResponse
+@attr.frozen
+class ApiVersionRequest(BaseStruct):
+    api_key: int = attr.field()
+    api_version: int = attr.field()
+
+
+@attr.frozen
+class ApiVersionResponse(BaseStruct):
+    error_code: int = attr.field()
+    api_versions: list = attr.field()
+
+
 # Requests and responses for consumer groups
 @attr.s(frozen=True, slots=True)
 class _JoinGroupRequestProtocol(object):

--- a/afkak/common.py
+++ b/afkak/common.py
@@ -79,6 +79,16 @@ class BaseStruct:
 # creating a message set
 @attr.frozen
 class SendRequest(BaseStruct):
+    """
+    Request to send a message to a topic
+
+    Attributes:
+        topic (str): The topic this request is for
+        key (bytes): The key for the message
+        messages (List[bytes]): The messages to include in the request
+        deferred (Deferred): The deferred to fire when the request is complete
+    """
+
     topic: str = attr.field()
     key: bytes = attr.field(default=None)
     messages: list = attr.field(default=None)
@@ -88,6 +98,15 @@ class SendRequest(BaseStruct):
 # Request payloads
 @attr.frozen
 class ProduceRequest(BaseStruct):
+    """
+    Request to produce a message to a topic/partition
+
+    Attributes:
+        topic (str): The topic this request is for
+        partition (int): The partition this request is for
+        messages (List[bytes]): The messages to include in the request
+    """
+
     topic: str = attr.field()
     partition: int = attr.field()
     messages: List[bytes] = attr.field(default=None)
@@ -98,6 +117,16 @@ class ProduceRequest(BaseStruct):
 
 @attr.frozen
 class FetchRequest(BaseStruct):
+    """
+    Request to fetch a set of messages from a topic/partition
+
+    Attributes:
+        topic (str): The topic this request is for
+        partition (int): The partition this request is for
+        offset (int): The offset to begin this fetch from
+        max_bytes (int): The maximum bytes to include in the message set for this partition
+    """
+
     topic: str = attr.field()
     partition: int = attr.field()
     offset: int = attr.field()
@@ -106,6 +135,16 @@ class FetchRequest(BaseStruct):
 
 @attr.frozen
 class OffsetRequest(BaseStruct):
+    """
+    Request to fetch the last committed offset for a set of partitions
+
+    Attributes:
+        topic (str): The topic this request is for
+        partition (int): The partition this request is for
+        time (int): The time to use for fetching offsets
+        max_offsets (int): The maximum number of offsets to return
+    """
+
     topic: str = attr.field()
     partition: int = attr.field()
     time: int = attr.field(default=None)
@@ -114,6 +153,18 @@ class OffsetRequest(BaseStruct):
 
 @attr.frozen
 class OffsetCommitRequest(BaseStruct):
+    """
+    Request to commit a specific offset for a topic/partition
+
+    Attributes:
+        topic (str): The topic this request is for
+        partition (int): The partition this request is for
+        offset (int): The offset to commit
+        timestamp (int): The timestamp of the commit
+        metadata (bytes): Any associated metadata the client wants to keep
+
+    """
+
     topic: str = attr.field()
     partition: int = attr.field()
     offset: int = attr.field()
@@ -123,6 +174,15 @@ class OffsetCommitRequest(BaseStruct):
 
 @attr.frozen
 class OffsetFetchRequest(BaseStruct):
+    """
+    Request to fetch the last committed offset for a set of partitions
+
+    Attributes:
+        topic (str): The topic this request is for
+        partition (int): The partition this request is for
+
+    """
+
     topic: str = attr.field()
     partition: int = attr.field()
 
@@ -130,6 +190,17 @@ class OffsetFetchRequest(BaseStruct):
 # Response payloads
 @attr.frozen
 class ProduceResponse(BaseStruct):
+    """
+    Response from a ProduceRequest
+
+    Attributes:
+        topic (str): The topic this response entry is for
+        partition (int): The partition this response entry is for
+        error (int): The error code for this request
+        offset (int): The offset of the message that was produced
+
+    """
+
     topic: str = attr.field()
     partition: int = attr.field()
     error: int = attr.field()
@@ -138,6 +209,18 @@ class ProduceResponse(BaseStruct):
 
 @attr.frozen
 class FetchResponse(BaseStruct):
+    """
+    Response from a FetchRequest
+
+    Attributes:
+        topic (str): The topic this response entry is for
+        partition (int): The partition this response entry is for
+        error (int): The error code for this request
+        highwaterMark (int): The offset of the last message in the partition
+        messages (list): The messages returned by the request
+
+    """
+
     topic: str = attr.field()
     partition: int = attr.field()
     error: int = attr.field()
@@ -147,6 +230,17 @@ class FetchResponse(BaseStruct):
 
 @attr.frozen
 class OffsetResponse(BaseStruct):
+    """
+    Response from an OffsetRequest
+
+    Attributes:
+        topic (str): The topic this response entry is for
+        partition (int): The partition this response entry is for
+        error (int): The error code for this request
+        offsets (list): The offsets returned by the request
+
+    """
+
     topic: str = attr.field()
     partition: int = attr.field()
     error: int = attr.field()
@@ -155,6 +249,16 @@ class OffsetResponse(BaseStruct):
 
 @attr.frozen
 class OffsetCommitResponse(BaseStruct):
+    """
+    Response from an OffsetCommitRequest
+
+    Attributes:
+        topic (str): The topic this response entry is for
+        partition (int): The partition this response entry is for
+        error (int): The error code for this request
+
+    """
+
     topic: str = attr.field()
     partition: int = attr.field()
     error: int = attr.field()
@@ -162,6 +266,18 @@ class OffsetCommitResponse(BaseStruct):
 
 @attr.frozen
 class OffsetFetchResponse(BaseStruct):
+    """
+    Response from an OffsetFetchRequest
+
+    Attributes:
+        topic (str): The topic this response entry is for
+        partition (int): The partition this response entry is for
+        offset (int): The offset for this partition
+        metadata (bytes): Any associated metadata the server has for this partition
+        error (int): The error code for this request
+
+    """
+
     topic: str = attr.field()
     partition: int = attr.field()
     offset: int = attr.field()
@@ -171,6 +287,17 @@ class OffsetFetchResponse(BaseStruct):
 
 @attr.frozen
 class ConsumerMetadataResponse(BaseStruct):
+    """
+    Response from a ConsumerMetadataRequest
+
+    Attributes:
+        error (int): The error code for this request
+        node_id (int): The node id for the coordinator
+        host (str): The hostname of the coordinator
+        port (int): The port for the coordinator
+
+    """
+
     error: int = attr.field()
     node_id: int = attr.field()
     host: str = attr.field()
@@ -180,6 +307,16 @@ class ConsumerMetadataResponse(BaseStruct):
 # Metadata tuples
 @attr.frozen
 class BrokerMetadata(BaseStruct):
+    """
+    Metadata for a single broker
+
+    Attributes:
+        node_id (int): The node id for this broker
+        host (str): The hostname of this broker
+        port (int): The port for this broker
+
+    """
+
     node_id: int = attr.field()
     host: str = attr.field()
     port: int = attr.field()
@@ -187,6 +324,16 @@ class BrokerMetadata(BaseStruct):
 
 @attr.frozen
 class TopicMetadata(BaseStruct):
+    """
+    Metadata for a single topic
+
+    Attributes:
+        topic (str): The topic name
+        topic_error_code (int): The error code for this topic
+        partition_metadata (list): The set of all partitions for this topic
+
+    """
+
     topic: str = attr.field()
     topic_error_code: int = attr.field()
     partition_metadata: List[bytes] = attr.field()
@@ -194,6 +341,19 @@ class TopicMetadata(BaseStruct):
 
 @attr.frozen
 class PartitionMetadata(BaseStruct):
+    """
+    Metadata for a single partition
+
+    Attributes:
+        topic (str): The topic name
+        partition (int): The partition id
+        partition_error_code (int): The error code for this partition
+        leader (int): The node id for the leader
+        replicas (list): The set of all nodes that host this partition
+        isr (list): The set of nodes that are in sync with the leader for this partition
+
+    """
+
     topic: str = attr.field()
     partition: int = attr.field()
     partition_error_code: int = attr.field()
@@ -205,12 +365,30 @@ class PartitionMetadata(BaseStruct):
 # ApiVersionRequest and ApiVersionResponse
 @attr.frozen
 class ApiVersionRequest(BaseStruct):
+    """
+    Request to discover supported API versions
+
+    Attributes:
+        api_key (int): The API key
+        api_version (int): The API version
+
+    """
+
     api_key: int = attr.field()
     api_version: int = attr.field()
 
 
 @attr.frozen
 class ApiVersionResponse(BaseStruct):
+    """
+    Response from an ApiVersionRequest
+
+    Attributes:
+        error_code (int): Response error code
+        api_versions (list): List of supported API versions
+
+    """
+
     error_code: int = attr.field()
     api_versions: list = attr.field()
 
@@ -218,13 +396,30 @@ class ApiVersionResponse(BaseStruct):
 # Requests and responses for consumer groups
 @attr.s(frozen=True, slots=True)
 class _JoinGroupRequestProtocol(object):
+    """
+    A protocol that the consumer supports.
+
+    Attributes:
+        protocol_name (str): The name of the protocol
+        protocol_metadata (bytes): The encoded metadata for the protocol
+    """
+
     protocol_name = attr.ib()
     protocol_metadata = attr.ib()
 
 
 @attr.s(frozen=True, slots=True)
 class _JoinGroupProtocolMetadata(object):
-    verison = attr.ib()
+    """
+    The metadata for a protocol that the consumer supports.
+
+    Attributes:
+        version (int): The version of the protocol
+        subscriptions (list): The list of topics that the consumer wants to subscribe to
+        user_data (bytes): Any additional data that the consumer wants to send to the group coordinator
+    """
+
+    version = attr.ib()
     subscriptions = attr.ib()
     user_data = attr.ib()
 
@@ -233,6 +428,15 @@ class _JoinGroupProtocolMetadata(object):
 class _JoinGroupRequest(object):
     """
     A request to join a coordinator group.
+
+    Attributes:
+        group (str): The name of the group to join
+        session_timeout (int): The time in milliseconds that the coordinator will wait for the consumer to send a
+            JoinGroupResponse
+        member_id (str): The unique identifier for the consumer. This is generated by the consumer and should be
+            unique across all consumers.
+        protocol_type (str): The type of protocol that the consumer supports
+        group_protocols (list): The list of protocols that the consumer supports
     """
 
     group = attr.ib()
@@ -244,12 +448,34 @@ class _JoinGroupRequest(object):
 
 @attr.s(frozen=True, slots=True)
 class _JoinGroupResponseMember(object):
+    """
+    A member of a consumer group.
+
+    Attributes:
+        member_id (str): The unique identifier for the consumer. This is generated by the consumer and should be
+            unique across all consumers.
+        member_metadata (bytes): The encoded metadata for the consumer
+    """
+
     member_id = attr.ib()
     member_metadata = attr.ib()
 
 
 @attr.s(frozen=True, slots=True)
 class _JoinGroupResponse(object):
+    """
+    A response from a coordinator group.
+
+    Attributes:
+        error (int): The error code for the request
+        generation_id (int): The generation id for the consumer group
+        group_protocol (str): The protocol that the group coordinator selected
+        leader_id (str): The unique identifier for the leader of the consumer group
+        member_id (str): The unique identifier for the consumer. This is generated by the consumer and should be
+            unique across all consumers.
+        members (list): The list of members in the consumer group
+    """
+
     error = attr.ib()
     generation_id = attr.ib()
     group_protocol = attr.ib()
@@ -260,12 +486,30 @@ class _JoinGroupResponse(object):
 
 @attr.s(frozen=True, slots=True)
 class _SyncGroupRequestMember(object):
+    """
+    A member of a consumer group.
+
+    Attributes:
+        member_id (str): The unique identifier for the consumer. This is generated by the consumer and should be
+            unique across all consumers.
+        member_metadata (bytes): The encoded metadata for the consumer
+    """
+
     member_id = attr.ib()
     member_metadata = attr.ib()
 
 
 @attr.s(frozen=True, slots=True)
 class _SyncGroupMemberAssignment(object):
+    """
+    The assignment for a member of a consumer group.
+
+    Attributes:
+        version (int): The version of the assignment
+        assignments (list): The list of partitions that the consumer is assigned to
+        user_data (bytes): Any additional data that the consumer wants to send to the group coordinator
+    """
+
     version = attr.ib()
     assignments = attr.ib()
     user_data = attr.ib()
@@ -273,6 +517,17 @@ class _SyncGroupMemberAssignment(object):
 
 @attr.s(frozen=True, slots=True)
 class _SyncGroupRequest(object):
+    """
+    A request to sync with a consumer group.
+
+    Attributes:
+        group (str): The name of the group to sync with
+        generation_id (int): The generation id for the consumer group
+        member_id (str): The unique identifier for the consumer. This is generated by the consumer and should be
+            unique across all consumers.
+        group_assignment (dict): The assignment for each member of the consumer group
+    """
+
     group = attr.ib()
     generation_id = attr.ib()
     member_id = attr.ib()
@@ -281,25 +536,123 @@ class _SyncGroupRequest(object):
 
 @attr.s(frozen=True, slots=True)
 class _SyncGroupResponse(object):
+    """
+    A response from a consumer group sync.
+
+    Attributes:
+        error (int): The error code for the request
+        member_assignment (bytes): The encoded assignment for the consumer
+    """
+
     error = attr.ib()
     member_assignment = attr.ib()
 
 
-_HeartbeatRequest = namedtuple("_HeartbeatRequest", ["group", "generation_id", "member_id"])
-_HeartbeatResponse = namedtuple("_HeartbeatResponse", ["error"])
+@attr.s(frozen=True, slots=True)
+class _HeartbeatRequest(BaseStruct):
+    """
+    A request to send a heartbeat to a consumer group coordinator.
 
-_LeaveGroupRequest = namedtuple("_LeaveGroupRequest", ["group", "member_id"])
-_LeaveGroupResponse = namedtuple("_LeaveGroupResponse", ["error"])
+    Attributes:
+        group (str): The name of the group to send a heartbeat to
+        generation_id (int): The generation id for the consumer group
+        member_id (str): The unique identifier for the consumer. This is generated by the consumer and should be
+            unique across all consumers.
+    """
+
+    group = attr.ib()
+    generation_id = attr.ib()
+    member_id = attr.ib()
+
+
+@attr.s(frozen=True, slots=True)
+class _HeartbeatResponse(BaseStruct):
+    """
+    A response from a consumer group heartbeat.
+
+    Attributes:
+        error (int): The error code for the request
+    """
+
+    error = attr.ib()
+
+
+@attr.s(frozen=True, slots=True)
+class _LeaveGroupRequest(BaseStruct):
+    """
+    A request to leave a consumer group.
+
+    Attributes:
+        group (str): The name of the group to leave
+        member_id (str): The unique identifier for the consumer. This is generated by the consumer and should be
+            unique across all consumers.
+    """
+
+    group = attr.ib()
+    member_id = attr.ib()
+
+
+@attr.s(frozen=True, slots=True)
+class _LeaveGroupResponse(BaseStruct):
+    """
+    A response from a consumer group leave.
+
+    Attributes:
+        error (int): The error code for the request
+    """
+
+    error = attr.ib()
+
 
 # Other useful structs
-OffsetAndMessage = namedtuple("OffsetAndMessage", ["offset", "message"])
+@attr.s(frozen=True, slots=True)
+class OffsetAndMessage(BaseStruct):
+    """
+    A message with an associated offset.
+
+    Attributes:
+        offset (int): The offset of the message
+        message (kafka.protocol.message.Message): The message
+    """
+
+    offset = attr.ib()
+    message = attr.ib()
 
 
-TopicAndPartition = namedtuple("TopicAndPartition", ["topic", "partition"])
-SourcedMessage = namedtuple("SourcedMessage", TopicAndPartition._fields + OffsetAndMessage._fields)
+@attr.s(frozen=True, slots=True)
+class TopicAndPartition(BaseStruct):
+    """
+    A topic and partition.
+
+    Attributes:
+        topic (str): The name of the topic
+        partition (int): The partition id
+    """
+
+    topic = attr.ib()
+    partition = attr.ib()
 
 
-class Message(namedtuple("Message", ["magic", "attributes", "key", "value"])):
+@attr.s(frozen=True, slots=True)
+class SourcedMessage(BaseStruct):
+    """
+    A message with an associated offset, topic, and partition.
+
+    Attributes:
+        topic (str): The name of the topic
+        partition (int): The partition id
+        offset (int): The offset of the message
+        message (kafka.protocol.message.Message): The message
+    """
+
+    topic = attr.ib()
+    partition = attr.ib()
+    offset = attr.ib()
+    message = attr.ib()
+
+
+@attr.s(frozen=True, slots=True, repr=False)
+class Message(BaseStruct):
     """
     A Kafka `message`_ in format 0.
 
@@ -314,7 +667,10 @@ class Message(namedtuple("Message", ["magic", "attributes", "key", "value"])):
     .. _message: https://kafka.apache.org/documentation/#messageset
     """
 
-    __slots__ = ()
+    magic = attr.field()
+    attributes = attr.field()
+    key = attr.field()
+    value = attr.field()
 
     def __repr__(self):
         bits = ["<Message v0"]

--- a/afkak/kafkacodec.py
+++ b/afkak/kafkacodec.py
@@ -101,7 +101,7 @@ class _ReprRequest:
     ListOffsetsRequest0 correlationId=16 (8 bytes)
     """
 
-    _request: bytes = attr.field()
+    _request: bytes = attr.ib()
 
     _REQUEST_HEADER = struct.Struct(">hhi")
 
@@ -438,10 +438,10 @@ class KafkaCodec(object):
         data = data[2:]  # move past correlation_id and error_code
 
         api_versions = []
-        while cur < len(data):
-            for api_key, min_version, max_version in struct.iter_unpack(">hhh", data[cur:]):
-                api_versions.append((api_key, min_version, max_version))
-                cur += 6
+
+        for api_key, min_version, max_version in struct.iter_unpack(">hhh", data[cur:]):
+            api_versions.append((api_key, min_version, max_version))
+            cur += 6
         return ApiVersionResponse(error_code, api_versions)
 
     @classmethod

--- a/afkak/kafkacodec.py
+++ b/afkak/kafkacodec.py
@@ -20,6 +20,7 @@ import struct
 import zlib
 from binascii import hexlify
 
+import attr
 from ._util import (
     group_by_topic_and_partition,
     read_int_string,
@@ -148,6 +149,47 @@ class KafkaCodec(object):
     API_VERSIONS_KEY = 18
     CREATE_TOPICS_KEY = 19
     DELETE_TOPICS_KEY = 20
+    DELETE_RECORDS_KEY = 21
+    INIT_PRODUCER_ID_KEY = 22
+    OFFSET_FOR_LEADER_EPOCH_KEY = 23
+    ADD_PARTITIONS_TO_TXN_KEY = 24
+    ADD_OFFSETS_TO_TXN_KEY = 25
+    END_TXN_KEY = 26
+    WRITE_TXN_MARKERS_KEY = 27
+    TXN_OFFSET_COMMIT_KEY = 28
+    DESCRIBE_ACLS_KEY = 29
+    CREATE_ACLS_KEY = 30
+    DELETE_ACLS_KEY = 31
+    DESCRIBE_CONFIGS_KEY = 32
+    ALTER_CONFIGS_KEY = 33
+    ALTER_REPLICA_LOG_DIRS_KEY = 34
+    DESCRIBE_LOG_DIRS_KEY = 35
+    SASL_AUTHENTICATE_KEY = 36
+    CREATE_PARTITIONS_KEY = 37
+    CREATE_DELEGATION_TOKEN_KEY = 38
+    RENEW_DELEGATION_TOKEN_KEY = 39
+    EXPIRE_DELEGATION_TOKEN_KEY = 40
+    DESCRIBE_DELEGATION_TOKEN_KEY = 41
+    DELETE_GROUPS_KEY = 42
+    ELECT_PREFERRED_LEADERS_KEY = 43
+    INCREMENTAL_ALTER_CONFIGS_KEY = 44
+    ALTER_PARTITION_REASSIGNMENTS_KEY = 45
+    LIST_PARTITION_REASSIGNMENTS_KEY = 46
+    OFFSET_DELETE_KEY = 47
+    DESCRIBE_CLIENT_QUOTAS_KEY = 48
+    ALTER_CLIENT_QUOTAS_KEY = 49
+    DESCRIBE_USER_SCRAM_CREDENTIALS_KEY = 50
+    ALTER_USER_SCRAM_CREDENTIALS_KEY = 51
+    DESCRIBE_QUORUM_KEY = 55
+    ALTER_PARTITION_KEY = 56
+    UPDATE_FEATURES_KEY = 57
+    ENVELOPE_KEY = 58
+    DESCRIBE_CLUSTER_KEY = 60
+    DESCRIBE_PRODUCERS_KEY = 61
+    UNREGISTER_BROKER_KEY = 64
+    DESCRIBE_TRANSACTIONS_KEY = 65
+    LIST_TRANSACTIONS_KEY = 66
+    ALLOCATE_PRODUCER_IDS_KEY = 67
 
     _key_to_name = {
         PRODUCE_KEY: "Produce",
@@ -167,6 +209,47 @@ class KafkaCodec(object):
         API_VERSIONS_KEY: "ApiVersions",
         CREATE_TOPICS_KEY: "CreateTopics",
         DELETE_TOPICS_KEY: "DeleteTopics",
+        DELETE_RECORDS_KEY: "DeleteRecords",
+        INIT_PRODUCER_ID_KEY: "InitProducerId",
+        OFFSET_FOR_LEADER_EPOCH_KEY: "OffsetForLeaderEpoch",
+        ADD_PARTITIONS_TO_TXN_KEY: "AddPartitionsToTxn",
+        ADD_OFFSETS_TO_TXN_KEY: "AddOffsetsToTxn",
+        END_TXN_KEY: "EndTxn",
+        WRITE_TXN_MARKERS_KEY: "WriteTxnMarkers",
+        TXN_OFFSET_COMMIT_KEY: "TxnOffsetCommit",
+        DESCRIBE_ACLS_KEY: "DescribeAcls",
+        CREATE_ACLS_KEY: "CreateAcls",
+        DELETE_ACLS_KEY: "DeleteAcls",
+        DESCRIBE_CONFIGS_KEY: "DescribeConfigs",
+        ALTER_CONFIGS_KEY: "AlterConfigs",
+        ALTER_REPLICA_LOG_DIRS_KEY: "AlterReplicaLogDirs",
+        DESCRIBE_LOG_DIRS_KEY: "DescribeLogDirs",
+        SASL_AUTHENTICATE_KEY: "SaslAuthenticate",
+        CREATE_PARTITIONS_KEY: "CreatePartitions",
+        CREATE_DELEGATION_TOKEN_KEY: "CreateDelegationToken",
+        RENEW_DELEGATION_TOKEN_KEY: "RenewDelegationToken",
+        EXPIRE_DELEGATION_TOKEN_KEY: "ExpireDelegationToken",
+        DESCRIBE_DELEGATION_TOKEN_KEY: "DescribeDelegationToken",
+        DELETE_GROUPS_KEY: "DeleteGroups",
+        ELECT_PREFERRED_LEADERS_KEY: "ElectPreferredLeaders",
+        INCREMENTAL_ALTER_CONFIGS_KEY: "IncrementalAlterConfigs",
+        ALTER_PARTITION_REASSIGNMENTS_KEY: "AlterPartitionReassignments",
+        LIST_PARTITION_REASSIGNMENTS_KEY: "ListPartitionReassignments",
+        OFFSET_DELETE_KEY: "OffsetDelete",
+        DESCRIBE_CLIENT_QUOTAS_KEY: "DescribeClientQuotas",
+        ALTER_CLIENT_QUOTAS_KEY: "AlterClientQuotas",
+        DESCRIBE_USER_SCRAM_CREDENTIALS_KEY: "DescribeUserScramCredentials",
+        ALTER_USER_SCRAM_CREDENTIALS_KEY: "AlterUserScramCredentials",
+        DESCRIBE_QUORUM_KEY: "DescribeQuorum",
+        ALTER_PARTITION_KEY: "AlterPartition",
+        UPDATE_FEATURES_KEY: "UpdateFeatures",
+        ENVELOPE_KEY: "Envelope",
+        DESCRIBE_CLUSTER_KEY: "DescribeCluster",
+        DESCRIBE_PRODUCERS_KEY: "DescribeProducers",
+        UNREGISTER_BROKER_KEY: "UnregisterBroker",
+        DESCRIBE_TRANSACTIONS_KEY: "DescribeTransactions",
+        LIST_TRANSACTIONS_KEY: "ListTransactions",
+        ALLOCATE_PRODUCER_IDS_KEY: "AllocateProducerIds",
     }
 
     @classmethod

--- a/afkak/kafkacodec.py
+++ b/afkak/kafkacodec.py
@@ -20,7 +20,6 @@ import struct
 import zlib
 from binascii import hexlify
 
-import attr
 from ._util import (
     group_by_topic_and_partition,
     read_int_string,
@@ -362,7 +361,7 @@ class KafkaCodec(object):
                 if read_message is False:
                     # If we get a partial read of a message, but haven't
                     # yielded anything there's a problem
-                    raise ConsumerFetchSizeTooSmall()
+                    raise ConsumerFetchSizeTooSmall() from None
                 else:
                     return
 

--- a/afkak/kafkacodec.py
+++ b/afkak/kafkacodec.py
@@ -441,7 +441,7 @@ class KafkaCodec(object):
 
         for api_key, min_version, max_version in struct.iter_unpack(">hhh", data[cur:]):
             api_versions.append((api_key, min_version, max_version))
-            cur += 6
+
         return ApiVersionResponse(error_code, api_versions)
 
     @classmethod

--- a/afkak/kafkacodec.py
+++ b/afkak/kafkacodec.py
@@ -432,14 +432,13 @@ class KafkaCodec(object):
                     MaxVersion => int16
         """
         ((correlation_id, error_code), cur) = relative_unpack(">ii", data, 0)
-        print("correlation_id: %d" % correlation_id)
-        print("error_code: %d" % error_code)
         data = data[2:]  # move past correlation_id and error_code
 
         api_versions = []
         while cur < len(data):
-            ((api_key, min_version, max_version), cur) = relative_unpack(">hhh", data, cur)
-            api_versions.append((api_key, min_version, max_version))
+            for api_key, min_version, max_version in struct.iter_unpack(">hhh", data[cur:]):
+                api_versions.append((api_key, min_version, max_version))
+                cur += 6
         return ApiVersionResponse(error_code, api_versions)
 
     @classmethod

--- a/afkak/test/int/intutil.py
+++ b/afkak/test/int/intutil.py
@@ -46,7 +46,7 @@ __all__ = [
 
 def stat(key, value):
     print(
-        "##teamcity[buildStatisticValue key='{}' value='{}']".format(key, value),
+        "{} : {}".format(key, value),
         file=sys.stderr,
     )
 

--- a/afkak/test/int/service.py
+++ b/afkak/test/int/service.py
@@ -50,7 +50,6 @@ class SpawnedService(object):
         proc = subprocess.Popen(
             self._args,
             env=self._env,
-            bufsize=1,  # Line buffered.
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )

--- a/afkak/test/int/test_client_integration.py
+++ b/afkak/test/int/test_client_integration.py
@@ -171,3 +171,13 @@ class TestAfkakClientIntegration(IntegrationMixin, unittest.TestCase):
         # Check we received the proper metadata in the response
         self.assertEqual(resp.metadata, metadata)
         log.debug("test_commit_fetch_offsets: Test Complete.")
+
+    @kafka_versions("1.1.1")
+    @inlineCallbacks
+    def test_get_api_versions(self):
+        """
+        Get the API versions from the broker.
+        """
+        resp = yield self.client._get_api_versions()
+
+        assert len(resp.api_versions) == 43  # 43 is the number of APIs in 1.1.1

--- a/afkak/test/int/test_group_integration.py
+++ b/afkak/test/int/test_group_integration.py
@@ -330,7 +330,7 @@ class TestAfkakGroupIntegration(IntegrationMixin, unittest.TestCase):
         self.addCleanup(coord.stop)
 
         # FIXME: This doesn't seem to get fired reliably.
-        coord_start_d
+        coord_start_d # noqa
         # self.addCleanup(lambda: coord_start_d)
 
         yield de
@@ -357,7 +357,7 @@ class TestAfkakGroupIntegration(IntegrationMixin, unittest.TestCase):
         self.addCleanup(coord2.stop)
 
         # FIXME: This doesn't seem to get fired reliably
-        coord2_start_d
+        coord2_start_d # noqa
         # self.addCleanup(lambda: coord2_start_d)
 
         yield de
@@ -459,7 +459,7 @@ class TestAfkakGroupIntegration(IntegrationMixin, unittest.TestCase):
         coord_start_d = coord.start()
         self.addCleanup(coord.stop)
         # FIXME: This doesn't seem to get fired reliably.
-        coord_start_d
+        coord_start_d # noqa
         # self.addCleanup(lambda: coord_start_d)
 
         yield wait_for_assignments(self.topic, self.num_partitions, [coord])
@@ -486,7 +486,7 @@ class TestAfkakGroupIntegration(IntegrationMixin, unittest.TestCase):
         coord2_start_d = coord2.start()
         self.addCleanup(coord2.stop)
         # FIXME: This doesn't seem to get fired reliably.
-        coord2_start_d
+        coord2_start_d # noqa
         # self.addCleanup(lambda: coord2_start_d)
 
         # send some messages and see that they're processed

--- a/afkak/test/int/test_group_integration.py
+++ b/afkak/test/int/test_group_integration.py
@@ -513,9 +513,15 @@ class TestAfkakGroupIntegration(IntegrationMixin, unittest.TestCase):
             [value] = yield self.send_messages(part, ["sentinel"])
             pending_sentinels[part] = value
         while pending_sentinels:
-            [message] = yield record_stream.get()
-            if pending_sentinels.get(message.partition) == message.message.value:
-                del pending_sentinels[message.partition]
+            message = yield record_stream.get()
+            matching_msgs = [
+                msg
+                for msg in message
+                for part, value in pending_sentinels.items()
+                if msg.partition == part and msg.message.value == value
+            ]
+            for msg in matching_msgs:
+                del pending_sentinels[msg.partition]
 
         # after the cluster has re-formed, send some more messages
         # and check that we get them too (and don't get the old messages again)

--- a/afkak/test/int/test_group_integration.py
+++ b/afkak/test/int/test_group_integration.py
@@ -330,7 +330,7 @@ class TestAfkakGroupIntegration(IntegrationMixin, unittest.TestCase):
         self.addCleanup(coord.stop)
 
         # FIXME: This doesn't seem to get fired reliably.
-        coord_start_d # noqa
+        coord_start_d  # noqa
         # self.addCleanup(lambda: coord_start_d)
 
         yield de
@@ -357,7 +357,7 @@ class TestAfkakGroupIntegration(IntegrationMixin, unittest.TestCase):
         self.addCleanup(coord2.stop)
 
         # FIXME: This doesn't seem to get fired reliably
-        coord2_start_d # noqa
+        coord2_start_d  # noqa
         # self.addCleanup(lambda: coord2_start_d)
 
         yield de
@@ -459,7 +459,7 @@ class TestAfkakGroupIntegration(IntegrationMixin, unittest.TestCase):
         coord_start_d = coord.start()
         self.addCleanup(coord.stop)
         # FIXME: This doesn't seem to get fired reliably.
-        coord_start_d # noqa
+        coord_start_d  # noqa
         # self.addCleanup(lambda: coord_start_d)
 
         yield wait_for_assignments(self.topic, self.num_partitions, [coord])
@@ -486,7 +486,7 @@ class TestAfkakGroupIntegration(IntegrationMixin, unittest.TestCase):
         coord2_start_d = coord2.start()
         self.addCleanup(coord2.stop)
         # FIXME: This doesn't seem to get fired reliably.
-        coord2_start_d # noqa
+        coord2_start_d  # noqa
         # self.addCleanup(lambda: coord2_start_d)
 
         # send some messages and see that they're processed

--- a/afkak/test/test_client.py
+++ b/afkak/test/test_client.py
@@ -2004,7 +2004,6 @@ class TestKafkaClient(unittest.TestCase):
         # Check the received response
         result = self.successResultOf(d)
         self.assertEqual(result.error_code, 0)
-        print(result.api_versions)
         self.assertEqual(len(result.api_versions), len(api_versions))
         expected_resp = ApiVersionResponse(error_code=0, api_versions=api_versions)
         self.assertEqual(result, expected_resp)

--- a/afkak/test/test_client.py
+++ b/afkak/test/test_client.py
@@ -29,6 +29,7 @@ from .. import KafkaClient
 from ..client import _normalize_hosts
 from ..client import log as client_log
 from ..common import (
+    ApiVersionResponse,
     BrokerMetadata,
     CoordinatorNotAvailable,
     FailedPayloadsError,
@@ -1974,6 +1975,39 @@ class TestKafkaClient(unittest.TestCase):
 
         # Topic with all the partitions having equal replicas & ISRs ARE
         self.assertTrue(client.topic_fully_replicated("Topic3"))
+
+    def test_get_api_versions(self):
+        """
+        The client can get the API versions supported by the brokers.
+        """
+        reactor, connections, client = self.client_with_metadata(brokers=[])
+
+        d = client._get_api_versions()
+        self.assertNoResult(d)
+
+        # Accept connection from the client
+        conn = connections.accept("bootstrap")
+        connections.flush()
+        req = self.successResultOf(conn.server.expectRequest(KafkaCodec.API_VERSIONS_KEY, 0, ANY))
+
+        api_versions = [(0, 0, 8), (1, 0, 11)]
+
+        # Pack response bytes
+        resp_bytes = struct.pack(">hi", 0, len(api_versions))
+        for api_key, min_version, max_version in api_versions:
+            resp_bytes += struct.pack(">hhh", api_key, min_version, max_version)
+
+        req.respond(resp_bytes)
+
+        connections.flush()
+
+        # Check the received response
+        result = self.successResultOf(d)
+        self.assertEqual(result.error_code, 0)
+        print(result.api_versions)
+        self.assertEqual(len(result.api_versions), len(api_versions))
+        expected_resp = ApiVersionResponse(error_code=0, api_versions=api_versions)
+        self.assertEqual(result, expected_resp)
 
 
 class NormalizeHostsTests(unittest.TestCase):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Afkak'
-copyright = u'2015–2019 Ciena Corporation'
+copyright = u'2015–2023 Ciena Corporation'
 author = u'Robert Thille'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,10 +71,13 @@ fixable = []
 target-version = "py39"
 select = [
     'E', # pycodestyle errors
-    'F', # flake8 errors
+    'F', # pyflakes
     'W', # pycodestyle warnings
     'B', # bugbear
     'TCH', # flake8-type checking
+    'PLE', # pylint errors
+    'PLC', # pylint conventions
+    'PLW', # pylint warnings
 ]
 
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ build-backend = "setuptools.build_meta"
 name = "afkak"
 dynamic = ["version"]
 authors = [
-        {name = "Robert Thille"},
-        {name = "Tom Most"},
-        {name = "Mark Vaught"}
+    {name = "Robert Thille"},
+    {name = "Tom Most"},
+    {name = "Mark Vaught"}
 ]
 requires-python = ">=3.7"
 
@@ -16,30 +16,30 @@ readme = "README.md"
 description = "Twisted Python client for Apache Kafka"
 keywords = ["kafka", "distributed messaging", "txkafka"]
 classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Framework :: Twisted',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
-        'Operating System :: MacOS :: MacOS X',
-        'Operating System :: POSIX',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
-        'Topic :: Communications',
-        'Topic :: System :: Distributed Computing',
+    'Development Status :: 5 - Production/Stable',
+    'Framework :: Twisted',
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: Apache Software License',
+    'Operating System :: MacOS :: MacOS X',
+    'Operating System :: POSIX',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: Implementation :: CPython',
+    'Programming Language :: Python :: Implementation :: PyPy',
+    'Topic :: Communications',
+    'Topic :: System :: Distributed Computing',
 ]
 
 dependencies = [
-        'attrs >= 19.2.0',  # For functioning auto_exc=True.
-        'Twisted >= 18.7.0',  # First release with @inlineCallbacks cancellation.
+    'attrs >= 19.2.0',  # For functioning auto_exc=True.
+    'Twisted >= 18.7.0',  # First release with @inlineCallbacks cancellation.
 ]
 maintainers = [
-        {name = "Ciena"},
-        {name = "Mark Vaught"}
+    {name = "Ciena"},
+    {name = "Mark Vaught"}
 ]
 
 
@@ -59,9 +59,28 @@ version = {attr = "afkak.__version__"}
 [tool.setuptools.packages]
 find = {}
 
+# format and linting
+
 [tool.black]
 line-length = 120
-target-version = ['py37', 'py38', 'py39']
 src = "afkak"
 skip-string-normalization=true
 
+[tool.ruff]
+fixable = []
+target-version = "py39"
+select = [
+    'E', # pycodestyle errors
+    'F', # flake8 errors
+    'W', # pycodestyle warnings
+    'B', # bugbear
+    'TCH', # flake8-type checking
+]
+
+line-length = 120
+
+show-fixes = true
+
+ignore = [
+    'B028', # ignore stacklevel warnings
+]

--- a/tox.ini
+++ b/tox.ini
@@ -35,12 +35,8 @@ extras =
 deps =
     coverage==4.0.1
     Twisted==21.2.0
-    lint: flake8
-    lint: black
+    lint: ruff
     lint: isort
-    py39-lint: flake8-isort
-    py39-lint: flake8-bugbear
-    pylint: pylint
 
 commands =
     int: {toxinidir}/tools/download-kafka {env:KAFKA_VERSION}
@@ -56,11 +52,9 @@ commands =
     # Run just the integration tests
     int: {envbindir}/trial {posargs:--rterrors afkak.test.int}
 
-    lint: flake8 --version
-    lint: flake8 afkak
-    lint: black --check afkak
+    lint: ruff check afkak
     lint: isort --check-only afkak
-    pylint: pylint afkak --rcfile={toxinidir}/.pylintrc --output-format={env:PYLINT_OUTPUT_FORMAT:colorized}
+
 
 [testenv:cov_erase]
 description = Clear any accumulated .coverage.* files.

--- a/tox.ini
+++ b/tox.ini
@@ -123,7 +123,6 @@ use_parentheses = True
 ensure_newline_before_comments = True
 line_length = 120
 
-
 [gh-actions]
 python =
     3.7: py37


### PR DESCRIPTION
more work towards #45 (working to create a new issue that tracks the overall effort/changes) 

this will be somewhat large so i would suggest going commit by commit .... the scope of this PR will be to setup support for afkak to make broker aware requests by fetching the api version when we setup the client as part of the metadata request
scope for this will be 

- [x] update the KafkaCodec keys to add the latest 
- [x] refactor structs from named tuples to class objects 
- [x] cleanup and improve the kafkacodec where possible 
- [x] enable [Ruff](https://beta.ruff.rs/docs/)! from discussion in #131 
- [x] fix #121 because is driving me nuts 😅 